### PR TITLE
Add 12-bit support

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -20,8 +20,8 @@ Formats/DPX/Flavors/RGB_10_FilledA_BE/10bit.dpx pass
 Formats/DPX/Flavors/RGB_10_FilledA_BE/checkerboard_1080p_nuke_bigendian_10bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_10_FilledA_LE/image090003.dpx pass
-Formats/DPX/Flavors/RGB_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_noalpha.dpx fail
-Formats/DPX/Flavors/RGB_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_noalpha.dpx fail
+Formats/DPX/Flavors/RGB_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_noalpha.dpx pass
+Formats/DPX/Flavors/RGB_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_12_Packed_BE/12bit.dpx fail
 Formats/DPX/Flavors/RGB_12_Packed_BE/af093_ifa2006350_10000086400.dpx fail
 Formats/DPX/Flavors/RGB_12_Packed_BE/RGB_12_bit.dpx fail

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -195,6 +195,7 @@ int ParseFile(const char* Name)
     string FileName_Template;
     string FileName_StartNumber;
     size_t Path_Pos=0;
+    string slices;
     if (!M.IsDetected)
     {
         DetectSequence(Name, Files, Path_Pos, FileName_Template, FileName_StartNumber);
@@ -217,6 +218,12 @@ int ParseFile(const char* Name)
                 return 1;
             }
             i++;
+            if (WriteToDisk_Data.IsFirstFrame)
+            {
+                stringstream t;
+                t << DPX.slice_x * DPX.slice_x;
+                slices = t.str();
+            }
             WriteToDisk_Data.IsFirstFrame = false;
 
             if (i >= Files.size())
@@ -285,7 +292,7 @@ int ParseFile(const char* Name)
             Command += Files[0];
             Command += "\"";
         }
-        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices 64 -strict -2 -attach \"" + OutFileName + "\" -metadata:s:t mimetype=application/octet-stream -metadata:s:t filename=rawcooked.id=1 \"";
+        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices " + slices + " -strict -2 -attach \"" + OutFileName + "\" -metadata:s:t mimetype=application/octet-stream -metadata:s:t filename=rawcooked.id=1 \"";
         Command += Files[0];
         Command += ".mkv\"";
 

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -34,6 +34,7 @@ public:
 
     // Info
     uint64_t                    Style;
+    size_t                      slice_x;
 
     // Error message
     const char*                 ErrorMessage();
@@ -42,14 +43,21 @@ public:
     {
         RGB_10_FilledA_LE,
         RGB_10_FilledA_BE,
+        RGB_12_Packed_BE,
+        RGB_12_FilledA_BE,
+        RGB_12_FilledA_LE,
         RGB_16_BE,
         RGBA_8,
+        RGBA_12_Packed_BE,
+        RGBA_12_FilledA_BE,
+        RGBA_12_FilledA_LE,
         RGBA_16_BE,
         DPX_Style_Max,
     };
 
     // Info about formats
     static size_t BitsPerPixel(style Style);
+    static size_t PixelSync(style Style); // Need no overlap every x pixels
 
 private:
     size_t                      Buffer_Offset;

--- a/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.h
+++ b/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.h
@@ -29,7 +29,6 @@ private:
     size_t                      Bits;
     pixel_t                     Offset;
     uint64_t                    Style_Private; //Used by specialized style for marking the configuration of such style (e.g. endianess of DPX)
-    uint64_t                    Status_Private; //Used by specialized style for marking private status (e.g. wich datum position in DPX)
     uint64_t                    Data_Private; //Used by specialized style for marking private status (e.g. wich data from previous datum in DPX)
 
     void FFmpeg_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);


### PR DESCRIPTION
12-bit packed currently deactivated, waiting for FFmpeg patch.

I also need to limit 12-bit packed to multiple of 8 (RGB) and 2 (RGBA) per slice in order to not have overlapping issues when transforming directly from FFV1 lines to DPX store method.