### PR TITLE
Add support of more 10-bit flavors

### DIFF
--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -50,6 +50,8 @@ public:
         RGB_16_BE,
         RGB_16_LE,
         RGBA_8,
+        RGBA_10_FilledA_LE,
+        RGBA_10_FilledA_BE,
         RGBA_12_Packed_BE,
         RGBA_12_FilledA_BE,
         RGBA_12_FilledA_LE,
@@ -59,8 +61,8 @@ public:
     };
 
     // Info about formats
-    static size_t BitsPerPixel(style Style);
-    static size_t PixelSync(style Style); // Need no overlap every x pixels
+    static size_t BitsPerBlock(style Style);
+    static size_t PixelsPerBlock(style Style); // Need no overlap every x pixels
 
 private:
     size_t                      Buffer_Offset;

--- a/Source/Lib/RawFrame/RawFrame.cpp
+++ b/Source/Lib/RawFrame/RawFrame.cpp
@@ -62,7 +62,7 @@ void raw_frame::DPX_Create(size_t colorspace_type, size_t width, size_t height, 
     switch (colorspace_type)
     {
         case 1: // JPEG2000-RCT --> RGB
-                Planes.push_back(new plane(width, height, dpx::BitsPerPixel((dpx::style)Style_Private)));
+                Planes.push_back(new plane(width, height, dpx::BitsPerBlock((dpx::style)Style_Private), dpx::PixelsPerBlock((dpx::style)Style_Private)));
         default: ;
     }
 }

--- a/Source/Lib/RawFrame/RawFrame.h
+++ b/Source/Lib/RawFrame/RawFrame.h
@@ -33,19 +33,21 @@ public:
         size_t                  Width;
         size_t                  Width_Padding;
         size_t                  Height;
-        size_t                  BitsPerPixel;
+        size_t                  BitsPerBlock;
+        size_t                  PixelsPerBlock;
 
-        plane(size_t Width_, size_t Height_, size_t BitsPerPixel_)
+        plane(size_t Width_, size_t Height_, size_t BitsPerBlock_, size_t PixelsPerBlock_ = 1)
             :
             Width(Width_),
             Height(Height_),
-            BitsPerPixel(BitsPerPixel_)
+            BitsPerBlock(BitsPerBlock_),
+            PixelsPerBlock(PixelsPerBlock_)
         {
             Width_Padding=0; //TODO: option for padding size
             if (Width_Padding)
                 Width_Padding-=Width%Width_Padding;
                 
-            Buffer_Size=(Width+Width_Padding)*Height*BitsPerPixel/8;
+            Buffer_Size=(Width+Width_Padding)*Height*BitsPerBlock/PixelsPerBlock/8;
             Buffer=new uint8_t[Buffer_Size];
             memset(Buffer, 0, Buffer_Size);
         }
@@ -57,12 +59,12 @@ public:
 
         size_t ValidBytesPerLine()
         {
-            return Width*BitsPerPixel/8;
+            return Width*BitsPerBlock/PixelsPerBlock/8;
         }
 
         size_t AllBytesPerLine()
         {
-            return (Width+Width_Padding)*BitsPerPixel/8;
+            return (Width+Width_Padding)*BitsPerBlock/PixelsPerBlock/8;
         }
     };
     std::vector<plane*> Planes;


### PR DESCRIPTION
The following flavors are added:
RGBA_10_FilledA_LE
RGBA_10_FilledA_BE

But are disabled because FFmpeg FFV1 encoder/decoder does not support them yet (patch will be sent to ffmpeg-devel).