### PR TITLE
FFV1 to RGBA_12_Packed_BE decoding

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -7,13 +7,16 @@ Formats/DPX/Flavors/RGBA_8_Packed_BE/RGBA_8_bit.dpx pass
 Formats/DPX/Flavors/RGBA_8_Packed_LE/checkerboard_1080p_nuke_littleendian_8bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_10_FilledA_BE/10bit_a.dpx fail
 Formats/DPX/Flavors/RGBA_10_FilledA_BE/checkerboard_1080p_nuke_bigendian_10bit_alpha.dpx fail
+Formats/DPX/Flavors/RGBA_10_FilledA_BE/converted_image_gets_skewed.dpx fail
 Formats/DPX/Flavors/RGBA_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_alpha.dpx fail
 Formats/DPX/Flavors/RGBA_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_alpha.dpx fail
 Formats/DPX/Flavors/RGBA_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_alpha.dpx fail
 Formats/DPX/Flavors/RGBA_12_Packed_BE/12bit_a.dpx fail
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_alpha.dpx pass
+Formats/DPX/Flavors/RGBA_16_FilledA_BE/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_alpha.dpx pass
-Formats/DPX/Flavors/RGBA_16_Packed_BE/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.dpx pass
+Formats/DPX/Flavors/RGBA_16_Packed_BE/16bit_a.dpx pass
+Formats/DPX/Flavors/RGBA_16_Packed_BE/16bit_a.2.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_BE/8bit.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_BE/checkerboard_1080p_nuke_bigendian_8bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_LE/checkerboard_1080p_nuke_littleendian_8bit_noalpha.dpx pass
@@ -29,5 +32,6 @@ Formats/DPX/Flavors/RGB_12_Packed_BE/RGB_12_bit.dpx fail
 Formats/DPX/Flavors/RGB_16F_Packed_BE/RGB_half_float_16_bit.dpx fail
 Formats/DPX/Flavors/RGB_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_noalpha.dpx pass
+Formats/DPX/Flavors/RGB_16_Packed_BE/16bit.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/058142ce-aeb9-4f5c-b3c7-7590f09c757d_00090000.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/RGB_16_bit.dpx pass

--- a/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.cpp
+++ b/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.cpp
@@ -262,6 +262,30 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                             s = 0;
                                         }
                                         break;
+            case dpx::RGBA_12_Packed_BE:
+                                        {
+                                        pixel_t a = A[x];
+                                        uint32_t c;
+                                        switch (s)
+                                        {
+                                            case 0:
+                                                    c = (b << 24) | (g << 12) | r;
+                                                    FrameBuffer_Temp_32[t] = ((c & 0xFF000000) >> 24) | ((c & 0x00FF0000) >> 8) | ((c & 0x0000FF00) << 8) | ((c & 0x000000FF) << 24); // Swap bytes
+                                                    Data_Private = (a << 4) | (b >> 8);
+                                                    break;
+                                            case 1:
+                                                    c = (g << 28) | (r << 16) | (uint32_t)Data_Private;
+                                                    FrameBuffer_Temp_32[t++] = ((c & 0xFF000000) >> 24) | ((c & 0x00FF0000) >> 8) | ((c & 0x0000FF00) << 8) | ((c & 0x000000FF) << 24); // Swap bytes
+                                                    c = (a << 20) | (b << 8) | (g >> 4);
+                                                    FrameBuffer_Temp_32[t] = ((c & 0xFF000000) >> 24) | ((c & 0x00FF0000) >> 8) | ((c & 0x0000FF00) << 8) | ((c & 0x000000FF) << 24); // Swap bytes
+                                                    break;
+                                        }
+                                        t++;
+                                        s++;
+                                        if (s == 2)
+                                            s = 0;
+                                        }
+                                        break;
             case dpx::RGBA_12_FilledA_BE:
                                         {
                                         pixel_t a = A[x];


### PR DESCRIPTION
RGBA_10_FilledA_BE test file still disabled due to FFmpeg FFV1 encoder lacking support of such format.