### PR TITLE
Support of multiple DPX or WAV streams

### DIFF
--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -17,6 +17,7 @@ rawcooked_SOURCES = \
     ../../../Source/Lib/Matroska/Matroska_Common.cpp \
     ../../../Source/Lib/RAWcooked/RAWcooked.cpp \
     ../../../Source/Lib/RawFrame/RawFrame.cpp \
+    ../../../Source/Lib/RIFF/RIFF.cpp \
     ../../../Source/Lib/ThirdParty/md5/md5.c
 
 AM_CPPFLAGS = -I../../../Source -I../../../Source/Lib/ThirdParty/thread-pool/include

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
@@ -79,6 +79,12 @@
     <Filter Include="Source Files\DPX">
       <UniqueIdentifier>{5154ec89-4df8-41dc-88cd-9f7fb3ea2f31}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\RIFF">
+      <UniqueIdentifier>{c0f1c942-c682-441f-b78d-18043ec4b2eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\RIFF">
+      <UniqueIdentifier>{e92f4c0c-4015-4076-8d5d-ec6dafb5e905}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\Lib\BitStream\BitStream.h">
@@ -138,6 +144,9 @@
     <ClInclude Include="..\..\..\Source\Lib\ThirdParty\thread-pool\include\ThreadPool.h">
       <Filter>ThirdParty\thread-pool</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\RIFF\RIFF.h">
+      <Filter>Header Files\RIFF</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\CRC32\CRC32.cpp">
@@ -181,6 +190,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\DPX\DPX.cpp">
       <Filter>Source Files\DPX</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\RIFF\RIFF.cpp">
+      <Filter>Source Files\RIFF</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/Source/Lib/Config.h
+++ b/Source/Lib/Config.h
@@ -21,6 +21,7 @@ typedef int32_t pixel_t;
 struct write_to_disk_struct
 {
     const char* FileName;
+    bool        IsFirstFile;
     bool        IsFirstFrame;
     const char* FileNameDPX;
 };

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -128,15 +128,8 @@ matroska::matroska() :
     WriteFrameCall(NULL),
     WriteFrameCall_Opaque(NULL),
     IsDetected(false),
-    DPX_Before(NULL),
-    DPX_After(NULL),
-    DPX_Buffer_Name(NULL),
-    DPX_Buffer_Pos(0),
-    DPX_Buffer_Count(0),
     RAWcooked_LibraryName_OK(false),
-    RAWcooked_LibraryVersion_OK(false),
-    R_A(NULL),
-    R_B(NULL)
+    RAWcooked_LibraryVersion_OK(false)
 {
     FramesPool = new ThreadPool(1);
     FramesPool->init();
@@ -230,6 +223,8 @@ void matroska::Segment_Attachments_AttachedFile_FileData()
         return;
 
     IsList = true;
+
+    TrackInfo_Pos = (size_t)-1;
 }
 
 //---------------------------------------------------------------------------
@@ -244,30 +239,34 @@ void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedBlock_AfterDat
     if (Levels[Level - 1].Offset_End - Buffer_Offset < 4 || Buffer[Buffer_Offset + 0] != 0x00 || Buffer[Buffer_Offset + 1] != 0x00 || Buffer[Buffer_Offset + 2] != 0x00 || Buffer[Buffer_Offset + 3] != 0x00)
         return;
 
-    DPX_Buffer_Count--; //TODO: right method for knowing the position
+    trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
 
-    if (!DPX_After)
+    TrackInfo_Current->DPX_Buffer_Count--; //TODO: right method for knowing the position
+
+    if (!TrackInfo_Current->DPX_After)
     {
-        DPX_After = new uint8_t*[1000000];
-        memset(DPX_After, 0x00, 1000000 * sizeof(uint8_t*));
-        DPX_After_Size = new uint64_t[1000000];
-        memset(DPX_After_Size, 0x00, 1000000 * sizeof(uint64_t));
+        TrackInfo_Current->DPX_After = new uint8_t*[1000000];
+        memset(TrackInfo_Current->DPX_After, 0x00, 1000000 * sizeof(uint8_t*));
+        TrackInfo_Current->DPX_After_Size = new uint64_t[1000000];
+        memset(TrackInfo_Current->DPX_After_Size, 0x00, 1000000 * sizeof(uint64_t));
     }
-    delete[] DPX_After[DPX_Buffer_Count];
-    DPX_After_Size[DPX_Buffer_Count] = Levels[Level].Offset_End - Buffer_Offset - 4;
-    DPX_After[DPX_Buffer_Count] = new uint8_t[DPX_After_Size[DPX_Buffer_Count]];
-    memcpy(DPX_After[DPX_Buffer_Count], Buffer + Buffer_Offset + 4, DPX_After_Size[DPX_Buffer_Count]);
-    DPX_Buffer_Count++;
+    delete[] TrackInfo_Current->DPX_After[TrackInfo_Current->DPX_Buffer_Count];
+    TrackInfo_Current->DPX_After_Size[TrackInfo_Current->DPX_Buffer_Count] = Levels[Level].Offset_End - Buffer_Offset - 4;
+    TrackInfo_Current->DPX_After[TrackInfo_Current->DPX_Buffer_Count] = new uint8_t[TrackInfo_Current->DPX_After_Size[TrackInfo_Current->DPX_Buffer_Count]];
+    memcpy(TrackInfo_Current->DPX_After[TrackInfo_Current->DPX_Buffer_Count], Buffer + Buffer_Offset + 4, TrackInfo_Current->DPX_After_Size[TrackInfo_Current->DPX_Buffer_Count]);
+    TrackInfo_Current->DPX_Buffer_Count++;
 }
 
 //---------------------------------------------------------------------------
 void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedBlock_FileName()
 {
-    if (!DPX_Buffer_Name)
+    trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
+
+    if (!TrackInfo_Current->DPX_Buffer_Name)
     {
-        DPX_Buffer_Name = new string[1000000];
+        TrackInfo_Current->DPX_Buffer_Name = new string[1000000];
     }
-    DPX_Buffer_Name[DPX_Buffer_Count] = string((const char*)Buffer + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
+    TrackInfo_Current->DPX_Buffer_Name[TrackInfo_Current->DPX_Buffer_Count] = string((const char*)Buffer + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
 }
 
 //---------------------------------------------------------------------------
@@ -276,24 +275,30 @@ void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedBlock_BeforeDa
     if (Levels[Level - 1].Offset_End - Buffer_Offset < 4 || Buffer[Buffer_Offset + 0] != 0x00 || Buffer[Buffer_Offset + 1] != 0x00 || Buffer[Buffer_Offset + 2] != 0x00 || Buffer[Buffer_Offset + 3] != 0x00)
         return;
 
-    if (!DPX_Before)
+    trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
+
+    if (!TrackInfo_Current->DPX_Before)
     {
-        DPX_Before = new uint8_t*[1000000];
-        memset(DPX_Before, 0x00, 1000000 * sizeof(uint8_t*));
-        DPX_Before_Size = new uint64_t[1000000];
-        memset(DPX_Before_Size, 0x00, 1000000 * sizeof(uint64_t));
+        TrackInfo_Current->DPX_Before = new uint8_t*[1000000];
+        memset(TrackInfo_Current->DPX_Before, 0x00, 1000000 * sizeof(uint8_t*));
+        TrackInfo_Current->DPX_Before_Size = new uint64_t[1000000];
+        memset(TrackInfo_Current->DPX_Before_Size, 0x00, 1000000 * sizeof(uint64_t));
     }
-    delete[] DPX_Before[DPX_Buffer_Count];
-    DPX_Before_Size[DPX_Buffer_Count] = Levels[Level].Offset_End - Buffer_Offset - 4;
-    DPX_Before[DPX_Buffer_Count] = new uint8_t[DPX_Before_Size[DPX_Buffer_Count]];
-    memcpy(DPX_Before[DPX_Buffer_Count], Buffer + Buffer_Offset + 4, DPX_Before_Size[DPX_Buffer_Count]);
-    DPX_Buffer_Count++;
+    delete[] TrackInfo_Current->DPX_Before[TrackInfo_Current->DPX_Buffer_Count];
+    TrackInfo_Current->DPX_Before_Size[TrackInfo_Current->DPX_Buffer_Count] = Levels[Level].Offset_End - Buffer_Offset - 4;
+    TrackInfo_Current->DPX_Before[TrackInfo_Current->DPX_Buffer_Count] = new uint8_t[TrackInfo_Current->DPX_Before_Size[TrackInfo_Current->DPX_Buffer_Count]];
+    memcpy(TrackInfo_Current->DPX_Before[TrackInfo_Current->DPX_Buffer_Count], Buffer + Buffer_Offset + 4, TrackInfo_Current->DPX_Before_Size[TrackInfo_Current->DPX_Buffer_Count]);
+    TrackInfo_Current->DPX_Buffer_Count++;
 }
 
 //---------------------------------------------------------------------------
 void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedTrack()
 {
     IsList = true;
+
+    TrackInfo_Pos++;
+    if (TrackInfo_Pos >= TrackInfo.size())
+        TrackInfo.push_back(new trackinfo());
 }
 
 //---------------------------------------------------------------------------
@@ -331,51 +336,56 @@ void matroska::Segment_Cluster()
 //---------------------------------------------------------------------------
 void matroska::Segment_Cluster_SimpleBlock()
 {
-    if (Levels[Level].Offset_End - Buffer_Offset > 4 && (Buffer[Buffer_Offset]&0x7F) == 1) // TODO: check the ID and format
+    if (Levels[Level].Offset_End - Buffer_Offset > 4)
     {
+        uint8_t TrackID = Buffer[Buffer_Offset] & 0x7F;
+        if (!TrackID || TrackID > TrackInfo.size())
+            return; // Problem
+        trackinfo* TrackInfo_Current = TrackInfo[TrackID - 1];
+
         // Load balacing between 2 frames (1 is parsed and 1 is written on disk), TODO: better handling
-        if (!R_A)
+        if (!TrackInfo_Current->R_A)
         {
             if (!RAWcooked_LibraryName_OK || !RAWcooked_LibraryVersion_OK)
                 exit(0);
-            R_A = new raw_frame;
-            R_B = new raw_frame;
+            TrackInfo_Current->R_A = new raw_frame;
+            TrackInfo_Current->R_B = new raw_frame;
         }
-        if (DPX_Buffer_Pos % 2)
-            Frame.RawFrame = R_B;
+        if (TrackInfo_Current->DPX_Buffer_Pos % 2)
+            TrackInfo_Current->Frame.RawFrame = TrackInfo_Current->R_B;
         else
-            Frame.RawFrame = R_A;
+            TrackInfo_Current->Frame.RawFrame = TrackInfo_Current->R_A;
 
-        if (DPX_Before && DPX_Before_Size[DPX_Buffer_Pos])
+        if (TrackInfo_Current->DPX_Before && TrackInfo_Current->DPX_Before_Size[TrackInfo_Current->DPX_Buffer_Pos])
         {
-            Frame.RawFrame->Pre = DPX_Before[DPX_Buffer_Pos];
-            Frame.RawFrame->Pre_Size = DPX_Before_Size[DPX_Buffer_Pos];
-            if (DPX_Buffer_Pos == 0)
+            TrackInfo_Current->Frame.RawFrame->Pre = TrackInfo_Current->DPX_Before[TrackInfo_Current->DPX_Buffer_Pos];
+            TrackInfo_Current->Frame.RawFrame->Pre_Size = TrackInfo_Current->DPX_Before_Size[TrackInfo_Current->DPX_Buffer_Pos];
+            if (TrackInfo_Current->DPX_Buffer_Pos == 0)
             {
                 dpx DPX;
-                DPX.Buffer = Frame.RawFrame->Pre;
-                DPX.Buffer_Size = Frame.RawFrame->Pre_Size;
+                DPX.Buffer = TrackInfo_Current->Frame.RawFrame->Pre;
+                DPX.Buffer_Size = TrackInfo_Current->Frame.RawFrame->Pre_Size;
                 if (DPX.Parse())
                     return;
-                R_A->Style_Private = DPX.Style;
-                R_B->Style_Private = DPX.Style;
+                TrackInfo_Current->R_A->Style_Private = DPX.Style;
+                TrackInfo_Current->R_B->Style_Private = DPX.Style;
             }
 
-            if (DPX_After && DPX_After_Size[DPX_Buffer_Pos])
+            if (TrackInfo_Current->DPX_After && TrackInfo_Current->DPX_After_Size[TrackInfo_Current->DPX_Buffer_Pos])
             {
-                Frame.RawFrame->Post = DPX_After[DPX_Buffer_Pos];
-                Frame.RawFrame->Post_Size = DPX_After_Size[DPX_Buffer_Pos];
+                TrackInfo_Current->Frame.RawFrame->Post = TrackInfo_Current->DPX_After[TrackInfo_Current->DPX_Buffer_Pos];
+                TrackInfo_Current->Frame.RawFrame->Post_Size = TrackInfo_Current->DPX_After_Size[TrackInfo_Current->DPX_Buffer_Pos];
             }
 
-            DPX_Buffer_Pos++;
+            TrackInfo_Current->DPX_Buffer_Pos++;
         }
-        Frame.Read_Buffer_Continue(Buffer + Buffer_Offset + 4, Levels[Level].Offset_End - Buffer_Offset - 4);
+        TrackInfo_Current->Frame.Read_Buffer_Continue(Buffer + Buffer_Offset + 4, Levels[Level].Offset_End - Buffer_Offset - 4);
         if (WriteFrameCall)
         {
             write_to_disk_struct* WriteToDisk_Data = (write_to_disk_struct*)WriteFrameCall_Opaque;
-            WriteToDisk_Data->FileNameDPX = DPX_Buffer_Name[DPX_Buffer_Pos - 1].c_str();
+            WriteToDisk_Data->FileNameDPX = TrackInfo_Current->DPX_Buffer_Name[TrackInfo_Current->DPX_Buffer_Pos - 1].c_str();
 
-            FramesPool->submit(WriteFrameCall, Buffer[Buffer_Offset] & 0x7F, Frame.RawFrame, WriteFrameCall_Opaque);
+            FramesPool->submit(WriteFrameCall, Buffer[Buffer_Offset] & 0x7F, TrackInfo_Current->Frame.RawFrame, WriteFrameCall_Opaque);
         }
     }
 }
@@ -384,12 +394,18 @@ void matroska::Segment_Cluster_SimpleBlock()
 void matroska::Segment_Tracks()
 {
     IsList = true;
+
+    TrackInfo_Pos = (size_t)-1;
 }
 
 //---------------------------------------------------------------------------
 void matroska::Segment_Tracks_TrackEntry()
 {
     IsList = true;
+
+    TrackInfo_Pos++;
+    if (TrackInfo_Pos >= TrackInfo.size())
+        TrackInfo.push_back(new trackinfo());
 }
 
 //---------------------------------------------------------------------------
@@ -403,7 +419,9 @@ void matroska::Segment_Tracks_TrackEntry_CodecPrivate()
 {
     if (Levels[Level].Offset_End - Buffer_Offset > 0x28)
     {
-        Frame.Read_Buffer_OutOfBand(Buffer + Buffer_Offset + 0x28, Levels[Level].Offset_End - Buffer_Offset - 0x28);
+        trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
+
+        TrackInfo_Current->Frame.Read_Buffer_OutOfBand(Buffer + Buffer_Offset + 0x28, Levels[Level].Offset_End - Buffer_Offset - 0x28);
     }
 }
 
@@ -415,7 +433,9 @@ void matroska::Segment_Tracks_TrackEntry_Video_PixelWidth()
         Data = ((uint32_t)Buffer[Buffer_Offset]);
     if (Levels[Level].Offset_End - Buffer_Offset == 2)
         Data = (((uint32_t)Buffer[Buffer_Offset]) << 8) | ((uint32_t)Buffer[Buffer_Offset + 1]);
-    Frame.SetWidth(Data);
+
+    trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
+    TrackInfo_Current->Frame.SetWidth(Data);
 }
 
 //---------------------------------------------------------------------------
@@ -426,5 +446,21 @@ void matroska::Segment_Tracks_TrackEntry_Video_PixelHeight()
         Data = ((uint32_t)Buffer[Buffer_Offset]);
     if (Levels[Level].Offset_End - Buffer_Offset == 2)
         Data = (((uint32_t)Buffer[Buffer_Offset]) << 8) | ((uint32_t)Buffer[Buffer_Offset + 1]);
-    Frame.SetHeight(Data);
+
+    trackinfo* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
+    TrackInfo_Current->Frame.SetHeight(Data);
+}
+
+//***************************************************************************
+// Errors
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+const char* matroska::ErrorMessage()
+{
+    for (size_t i = 0; i < TrackInfo.size(); i++)
+        if (TrackInfo[i]->Frame.ErrorMessage())
+            return TrackInfo[i]->Frame.ErrorMessage();
+
+    return NULL;
 }

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -13,6 +13,7 @@
 #include "Lib/FFV1/FFV1_Frame.h"
 #include <cstdint>
 #include <string>
+#include <vector>
 //---------------------------------------------------------------------------
 
 class matroska_mapping;
@@ -31,13 +32,14 @@ public:
 
     void                        Parse();
 
-    frame                       Frame;
-
     write_frame_call            WriteFrameCall;
     void*                       WriteFrameCall_Opaque;
 
     // Info
     bool                        IsDetected;
+
+    // Error message
+    const char*                 ErrorMessage();
 
 private:
     uint64_t                    Buffer_Offset;
@@ -84,15 +86,35 @@ private:
 
     bool                        RAWcooked_LibraryName_OK;
     bool                        RAWcooked_LibraryVersion_OK;
-    uint8_t**                   DPX_Before;
-    uint8_t**                   DPX_After;
-    uint64_t*                   DPX_Before_Size;
-    uint64_t*                   DPX_After_Size;
-    string*                     DPX_Buffer_Name;
-    size_t                      DPX_Buffer_Pos;
-    size_t                      DPX_Buffer_Count;
-    raw_frame*                  R_A;
-    raw_frame*                  R_B;
+    struct trackinfo
+    {
+        uint8_t**               DPX_Before;
+        uint8_t**               DPX_After;
+        uint64_t*               DPX_Before_Size;
+        uint64_t*               DPX_After_Size;
+        string*                 DPX_Buffer_Name;
+        size_t                  DPX_Buffer_Pos;
+        size_t                  DPX_Buffer_Count;
+        raw_frame*              R_A;
+        raw_frame*              R_B;
+        frame                   Frame;
+
+        trackinfo() :
+            DPX_Before(NULL),
+            DPX_After(NULL),
+            DPX_Before_Size(0),
+            DPX_After_Size(0),
+            DPX_Buffer_Name(NULL),
+            DPX_Buffer_Pos(0),
+            DPX_Buffer_Count(0),
+            R_A(NULL),
+            R_B(NULL)
+            {
+            }
+    };
+    vector<trackinfo*>          TrackInfo;
+    size_t                      TrackInfo_Pos;
+    vector<uint8_t>             ID_to_TrackOrder;
     ThreadPool*                 FramesPool;
 };
 

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -31,6 +31,7 @@ public:
     uint64_t                    Buffer_Size;
 
     void                        Parse();
+    void                        Shutdown();
 
     write_frame_call            WriteFrameCall;
     void*                       WriteFrameCall_Opaque;
@@ -72,17 +73,29 @@ private:
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_BeforeData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_FileName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_AfterData);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_BeforeData);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_FileName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_LibraryName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_LibraryVersion);
     MATROSKA_ELEMENT(Segment_Cluster);
     MATROSKA_ELEMENT(Segment_Cluster_SimpleBlock);
     MATROSKA_ELEMENT(Segment_Tracks);
     MATROSKA_ELEMENT(Segment_Tracks_TrackEntry);
+    MATROSKA_ELEMENT(Segment_Tracks_TrackEntry_CodecID);
     MATROSKA_ELEMENT(Segment_Tracks_TrackEntry_CodecPrivate);
     MATROSKA_ELEMENT(Segment_Tracks_TrackEntry_Video);
     MATROSKA_ELEMENT(Segment_Tracks_TrackEntry_Video_PixelWidth);
     MATROSKA_ELEMENT(Segment_Tracks_TrackEntry_Video_PixelHeight);
     MATROSKA_ELEMENT(Void);
+
+    enum format
+    {
+        Format_None,
+        Format_FFV1,
+        Format_PCM,
+        Format_Max,
+    };
 
     bool                        RAWcooked_LibraryName_OK;
     bool                        RAWcooked_LibraryVersion_OK;
@@ -98,6 +111,8 @@ private:
         raw_frame*              R_A;
         raw_frame*              R_B;
         frame                   Frame;
+        bool                    Unique;
+        format                  Format;
 
         trackinfo() :
             DPX_Before(NULL),
@@ -108,7 +123,9 @@ private:
             DPX_Buffer_Pos(0),
             DPX_Buffer_Count(0),
             R_A(NULL),
-            R_B(NULL)
+            R_B(NULL),
+            Unique(false),
+            Format(Format_None)
             {
             }
     };

--- a/Source/Lib/RAWcooked/RAWcooked.h
+++ b/Source/Lib/RAWcooked/RAWcooked.h
@@ -21,6 +21,8 @@ class rawcooked
 public:
     rawcooked();
 
+    bool                        Unique; // If set, data is for the whole stream (unique file)
+
     uint8_t*                    Before;
     uint64_t                    Before_Size;
 

--- a/Source/Lib/RIFF/RIFF.cpp
+++ b/Source/Lib/RIFF/RIFF.cpp
@@ -1,0 +1,209 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a MIT-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+#include "Lib/RIFF/RIFF.h"
+#include "Lib/RAWcooked/RAWcooked.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Tested cases
+enum endianess
+{
+    LE,
+    BE,
+};
+
+struct riff_tested
+{
+    uint32_t                    SamplingRate;
+    uint8_t                     BitDepth;
+    uint32_t                    ChannelCount;
+    endianess                   Endianess;
+    riff::style                 Style;
+};
+
+const size_t RIFF_Tested_Size = 26;
+struct riff_tested RIFF_Tested[RIFF_Tested_Size] =
+{
+    { 48000, 16, 2, LE, riff::PCM_48000_16_2_LE },
+    { 48000, 16, 6, LE, riff::PCM_48000_16_6_LE },
+    { 48000, 24, 2, LE, riff::PCM_48000_24_2_LE },
+    { 48000, 24, 6, LE, riff::PCM_48000_24_6_LE },
+};
+
+//---------------------------------------------------------------------------
+
+
+#define ELEMENT_BEGIN(_VALUE) \
+riff::call riff::SubElements_##_VALUE(uint64_t Name) \
+{ \
+    switch (Name) \
+    { \
+
+#define ELEMENT_CASE(_VALUE,_NAME) \
+    case 0x##_VALUE:  Levels[Level].SubElements = &riff::SubElements_##_NAME;  return &riff::_NAME;
+
+#define ELEMENT_VOID(_VALUE,_NAME) \
+    case 0x##_VALUE:  Levels[Level].SubElements = &riff::SubElements_Void;  return &riff::_NAME;
+
+
+#define ELEMENT_END() \
+    default:                        return SubElements_Void(Name); \
+    } \
+} \
+
+ELEMENT_BEGIN(_)
+ELEMENT_CASE(57415645, WAVE)
+ELEMENT_END()
+
+ELEMENT_BEGIN(WAVE)
+ELEMENT_VOID(64617461, WAVE_data)
+ELEMENT_END()
+
+
+//---------------------------------------------------------------------------
+riff::call riff::SubElements_Void(uint64_t Name)
+{
+    Levels[Level].SubElements = &riff::SubElements_Void; return &riff::Void;
+}
+
+//***************************************************************************
+// Errors
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+const char* riff::ErrorMessage()
+{
+    return error_message;
+}
+
+//***************************************************************************
+// DPX
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+riff::riff() :
+    WriteFileCall(NULL),
+    WriteFileCall_Opaque(NULL),
+    IsDetected(false),
+    Style(PCM_Style_Max),
+    error_message(NULL)
+{
+}
+
+//---------------------------------------------------------------------------
+uint16_t riff::Get_L2()
+{
+    uint16_t ToReturn = Buffer[Buffer_Offset + 0] | (Buffer[Buffer_Offset + 1] << 8);
+    Buffer_Offset += 2;
+    return ToReturn;
+}
+
+//---------------------------------------------------------------------------
+uint32_t riff::Get_L4()
+{
+    uint32_t ToReturn = Buffer[Buffer_Offset+0] | (Buffer[Buffer_Offset + 1] << 8) | (Buffer[Buffer_Offset + 2] << 16) | (Buffer[Buffer_Offset + 3] << 24);
+    Buffer_Offset += 4;
+    return ToReturn;
+}
+
+//---------------------------------------------------------------------------
+uint32_t riff::Get_B4()
+{
+    uint32_t ToReturn = (Buffer[Buffer_Offset + 0] << 24) | (Buffer[Buffer_Offset + 1] << 16) | (Buffer[Buffer_Offset + 2] << 8) | Buffer[Buffer_Offset + 3];
+    Buffer_Offset += 4;
+    return ToReturn;
+}
+
+//---------------------------------------------------------------------------
+bool riff::Parse()
+{
+    if (Buffer_Size < 4 || Buffer[0] != 'R' || Buffer[1] != 'I' || Buffer[2] != 'F' || Buffer[3] != 'F')
+        return false;
+
+    IsDetected = true;
+    Buffer_Offset = 0;
+    Level = 0;
+
+    Levels[Level].Offset_End = Buffer_Size;
+    Levels[Level].SubElements = &riff::SubElements__;
+    Level++;
+
+    while (Buffer_Offset < Buffer_Size)
+    {
+        uint32_t Name = Get_B4();
+        uint32_t Size = Get_L4();
+        if (Name == 0x52494646) // "RIFF"
+            Name = Get_B4();
+        Levels[Level].Offset_End = Buffer_Offset + Size;
+        call Call = (this->*Levels[Level - 1].SubElements)(Name);
+        IsList = false;
+        (this->*Call)();
+        if (!IsList)
+            Buffer_Offset = Levels[Level].Offset_End;
+        if (Buffer_Offset < Levels[Level].Offset_End)
+            Level++;
+        else
+        {
+            while (Buffer_Offset >= Levels[Level - 1].Offset_End)
+            {
+                Levels[Level].SubElements = NULL;
+                Level--;
+            }
+        }
+    }
+
+    return 0;
+}
+
+//---------------------------------------------------------------------------
+size_t riff::BitsPerBlock(riff::style Style)
+{
+    switch (Style)
+    {
+        case riff::PCM_48000_16_2_LE:   // 2x16-bit content
+                                        return 32;
+        case riff::PCM_48000_16_6_LE:   // 6x16-bit content
+                                        return 96;
+        case riff::PCM_48000_24_2_LE:   // 2x24-bit content
+                                        return 48;
+        case riff::PCM_48000_24_6_LE:   // 6x24-bit content
+                                        return 144;
+        default:
+                                        return 0;
+    }
+}
+
+//---------------------------------------------------------------------------
+void riff::Void()
+{
+}
+
+//---------------------------------------------------------------------------
+void riff::WAVE()
+{
+    IsList = true;
+}
+
+//---------------------------------------------------------------------------
+void riff::WAVE_data()
+{
+    // Write RAWcooked file
+    if (WriteFileCall)
+    {
+        rawcooked RAWcooked;
+        RAWcooked.Unique = true;
+        RAWcooked.WriteFileCall = WriteFileCall;
+        RAWcooked.WriteFileCall_Opaque = WriteFileCall_Opaque;
+        RAWcooked.Before = Buffer;
+        RAWcooked.Before_Size = Buffer_Offset;
+        RAWcooked.After = Buffer + Levels[Level].Offset_End;
+        RAWcooked.After_Size = Buffer_Size - Levels[Level].Offset_End;
+        RAWcooked.Parse();
+    }
+}
+

--- a/Source/Lib/RIFF/RIFF.h
+++ b/Source/Lib/RIFF/RIFF.h
@@ -1,0 +1,88 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a MIT-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+#ifndef RIFFH
+#define RIFFH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "Lib/FFV1/FFV1_Frame.h"
+#include <cstdint>
+#include <cstddef>
+//---------------------------------------------------------------------------
+
+typedef void(*write_file_call)(uint8_t*, size_t, void*);
+
+class riff
+{
+public:
+    riff();
+
+    uint8_t*                    Buffer;
+    uint64_t                    Buffer_Size;
+
+    bool                        Parse();
+
+    frame                       Frame;
+
+    write_file_call             WriteFileCall;
+    void*                       WriteFileCall_Opaque;
+
+    // Info
+    bool                        IsDetected;
+    uint64_t                    Style;
+
+    // Error message
+    const char*                 ErrorMessage();
+
+    enum style
+    {
+        PCM_48000_16_2_LE,
+        PCM_48000_16_6_LE,
+        PCM_48000_24_2_LE,
+        PCM_48000_24_6_LE,
+        PCM_Style_Max,
+    };
+
+    // Info about formats
+    static size_t BitsPerBlock(style Style);
+
+private:
+    size_t                      Buffer_Offset;
+    uint16_t                    Get_L2();
+    uint32_t                    Get_L4();
+    uint32_t                    Get_B4();
+
+    typedef void (riff::*call)();
+    typedef call(riff::*name)(uint64_t);
+
+    static const size_t Levels_Max = 16;
+    struct levels_struct
+    {
+        name SubElements;
+        uint64_t Offset_End;
+    };
+    levels_struct Levels[Levels_Max];
+    size_t Level;
+    bool IsList;
+
+#define RIFF_ELEMENT(_NAME) \
+        void _NAME(); \
+        call SubElements_##_NAME(uint64_t Name);
+
+    RIFF_ELEMENT(_);
+    RIFF_ELEMENT(WAVE);
+    RIFF_ELEMENT(WAVE_data);
+    RIFF_ELEMENT(Void);
+
+    // Error message
+    const char*                 error_message;
+    bool                        Error(const char* Error) { error_message = Error; return true; }
+};
+
+//---------------------------------------------------------------------------
+#endif

--- a/Source/Lib/RawFrame/RawFrame.h
+++ b/Source/Lib/RawFrame/RawFrame.h
@@ -25,6 +25,9 @@ public:
     size_t                      Pre_Size;
     uint8_t*                    Post;
     size_t                      Post_Size;
+    uint8_t*                    Buffer;
+    size_t                      Buffer_Size;
+    bool                        Buffer_IsOwned;
 
     struct plane
     {
@@ -79,12 +82,16 @@ public:
     raw_frame() :
         Style_Private(0),
         Pre(NULL),
-        Post(NULL)
+        Post(NULL),
+        Buffer(NULL)
     {
     }
     
     ~raw_frame()
     {
+        if (Buffer && Buffer_IsOwned)
+            delete[] Buffer;
+
         for (size_t i = 0; i < Planes.size(); i++)
             delete Planes[i];
     }


### PR DESCRIPTION
First version of the support of multiple DPX or WAV streams.
Tested with [3 video streams and 2 audio streams](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/tree/master/Features/AV_Package/818_DCDM_P3_IA_FIC_000918).

Code needs a big refactoring, but this version helps for confirming that RAWcooked reversibility file format is fine, and we can start to add corresponding regression tests.