### PR TITLE
RGBA 10- and 12-bit tests

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -35,3 +35,4 @@ Formats/DPX/Flavors/RGB_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit
 Formats/DPX/Flavors/RGB_16_Packed_BE/16bit.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/058142ce-aeb9-4f5c-b3c7-7590f09c757d_00090000.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/RGB_16_bit.dpx pass
+Formats/DPX/Flavors/RGB_16_Packed_LE/Dufay_000001.dpx pass

--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -5,12 +5,12 @@ Formats/DPX/Flavors/RGBA_8_FilledA_BE/checkerboard_1080p_nuke_bigendian_8bit_alp
 Formats/DPX/Flavors/RGBA_8_Packed_BE/8bit_a.dpx pass
 Formats/DPX/Flavors/RGBA_8_Packed_BE/RGBA_8_bit.dpx pass
 Formats/DPX/Flavors/RGBA_8_Packed_LE/checkerboard_1080p_nuke_littleendian_8bit_alpha.dpx pass
-Formats/DPX/Flavors/RGBA_10_FilledA_BE/10bit_a.dpx fail
-Formats/DPX/Flavors/RGBA_10_FilledA_BE/checkerboard_1080p_nuke_bigendian_10bit_alpha.dpx fail
+Formats/DPX/Flavors/RGBA_10_FilledA_BE/10bit_a.dpx pass
+Formats/DPX/Flavors/RGBA_10_FilledA_BE/checkerboard_1080p_nuke_bigendian_10bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_10_FilledA_BE/converted_image_gets_skewed.dpx fail
-Formats/DPX/Flavors/RGBA_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_alpha.dpx fail
-Formats/DPX/Flavors/RGBA_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_alpha.dpx fail
-Formats/DPX/Flavors/RGBA_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_alpha.dpx fail
+Formats/DPX/Flavors/RGBA_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_alpha.dpx pass
+Formats/DPX/Flavors/RGBA_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_alpha.dpx pass
+Formats/DPX/Flavors/RGBA_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_12_Packed_BE/12bit_a.dpx fail
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.dpx pass

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
@@ -35,6 +35,7 @@
     <ClInclude Include="..\..\..\Source\Lib\Matroska\Matroska_Common.h" />
     <ClInclude Include="..\..\..\Source\Lib\RAWcooked\RAWcooked.h" />
     <ClInclude Include="..\..\..\Source\Lib\RawFrame\RawFrame.h" />
+    <ClInclude Include="..\..\..\Source\Lib\RIFF\RIFF.h" />
     <ClInclude Include="..\..\..\Source\Lib\ThirdParty\md5\md5.h" />
     <ClInclude Include="..\..\..\Source\Lib\ThirdParty\thread-pool\include\SafeQueue.h" />
     <ClInclude Include="..\..\..\Source\Lib\ThirdParty\thread-pool\include\ThreadPool.h" />
@@ -53,6 +54,7 @@
     <ClCompile Include="..\..\..\Source\Lib\Matroska\Matroska_Common.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\RAWcooked\RAWcooked.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\RawFrame\RawFrame.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\RIFF\RIFF.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\ThirdParty\md5\md5.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -377,7 +377,7 @@ int FFmpeg_Command(const char* FileName)
 
     // Output
     if (!FFmpeg_Info[0].Slices.empty())
-        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices " + FFmpeg_Info[0].Slices + " -strict -2";
+        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices " + FFmpeg_Info[0].Slices;
     Command += " -c:a copy";
     Command += " -attach \"" + OutFileName + "\" -metadata:s:t mimetype=application/octet-stream -metadata:s:t \"filename=RAWcooked reversibility data\" \"";
     Command += FileName;

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -50,7 +50,7 @@ struct dpx_tested
     dpx::style                  Style;
 };
 
-const size_t DPX_Tested_Size = 20;
+const size_t DPX_Tested_Size = 24;
 struct dpx_tested DPX_Tested[DPX_Tested_Size] =
 {
     { RGB       ,  8, Packed , BE, dpx::RGB_8 },
@@ -70,11 +70,11 @@ struct dpx_tested DPX_Tested[DPX_Tested_Size] =
     { RGBA      ,  8, Packed , LE, dpx::RGBA_8 },
     { RGBA      ,  8, MethodA, BE, dpx::RGBA_8 },
     { RGBA      ,  8, MethodA, LE, dpx::RGBA_8 },
-//    { RGBA      , 10, MethodA, LE, dpx::RGBA_10_FilledA_LE },
-//    { RGBA      , 10, MethodA, BE, dpx::RGBA_10_FilledA_BE },
-//    { RGBA      , 12, Packed , BE, dpx::RGBA_12_Packed_BE }, // Not supported by FFmpeg DPX parser and FFmpeg FFV1 codec
-//    { RGBA      , 12, MethodA, BE, dpx::RGBA_12_FilledA_BE }, // Not supported by FFmpeg FFV1 codec
-//    { RGBA      , 12, MethodA, LE, dpx::RGBA_12_FilledA_LE }, // Not supported by FFmpeg FFV1 codec
+    { RGBA      , 10, MethodA, LE, dpx::RGBA_10_FilledA_LE },
+    { RGBA      , 10, MethodA, BE, dpx::RGBA_10_FilledA_BE },
+//    { RGBA      , 12, Packed , BE, dpx::RGBA_12_Packed_BE }, // Not supported by FFmpeg DPX parser
+    { RGBA      , 12, MethodA, BE, dpx::RGBA_12_FilledA_BE },
+    { RGBA      , 12, MethodA, LE, dpx::RGBA_12_FilledA_LE },
     { RGBA      , 16, Packed , BE, dpx::RGBA_16_BE },
     { RGBA      , 16, Packed , LE, dpx::RGBA_16_LE },
     { RGBA      , 16, MethodA, BE, dpx::RGBA_16_BE },


### PR DESCRIPTION
RGBA 10- and 12-bit are now accepted by FFmpeg after [my FFmpeg related commit](https://git.videolan.org/?p=ffmpeg.git;a=commit;h=fb580731c1febec44e0f1ec1433f6b3ee89cfe65), so enabling them in the automatic tests