### PR TITLE
[Stalled] DPX RGBA 12-bit packed enabled

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -11,7 +11,7 @@ Formats/DPX/Flavors/RGBA_10_FilledA_BE/converted_image_gets_skewed.dpx fail
 Formats/DPX/Flavors/RGBA_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_alpha.dpx pass
-Formats/DPX/Flavors/RGBA_12_Packed_BE/12bit_a.dpx fail
+Formats/DPX/Flavors/RGBA_12_Packed_BE/12bit_a.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_alpha.dpx pass

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -50,7 +50,7 @@ struct dpx_tested
     dpx::style                  Style;
 };
 
-const size_t DPX_Tested_Size = 25;
+const size_t DPX_Tested_Size = 26;
 struct dpx_tested DPX_Tested[DPX_Tested_Size] =
 {
     { RGB       ,  8, Packed , BE, dpx::RGB_8 },
@@ -72,7 +72,7 @@ struct dpx_tested DPX_Tested[DPX_Tested_Size] =
     { RGBA      ,  8, MethodA, LE, dpx::RGBA_8 },
     { RGBA      , 10, MethodA, LE, dpx::RGBA_10_FilledA_LE },
     { RGBA      , 10, MethodA, BE, dpx::RGBA_10_FilledA_BE },
-//    { RGBA      , 12, Packed , BE, dpx::RGBA_12_Packed_BE }, // Not supported by FFmpeg DPX parser
+    { RGBA      , 12, Packed , BE, dpx::RGBA_12_Packed_BE },
     { RGBA      , 12, MethodA, BE, dpx::RGBA_12_FilledA_BE },
     { RGBA      , 12, MethodA, LE, dpx::RGBA_12_FilledA_LE },
     { RGBA      , 16, Packed , BE, dpx::RGBA_16_BE },


### PR DESCRIPTION
Will fail as upstream FFmpeg is ignoring my patch for support of DPX 12-bit packed, either RGB+RGBA or limited to RGB.
You can use DPX 12-bit packed by compiling this branch of RAWcooked and compiling FFmpeg with [this DPX 12-bit packed FFmpeg patch](https://ffmpeg.org/pipermail/ffmpeg-devel/2018-February/225073.html) (alternative: [the RGB-only version](https://ffmpeg.org/pipermail/ffmpeg-devel/2018-February/225355.html)).

The branch is for reference only, and will be deleted if my own DPX to FFV1 encoder arrives first.