### PR TITLE
Add EBML header

### DIFF
--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -61,7 +61,7 @@ while read line ; do
                 rcode=1
                 continue
             fi
-            rm -f "${file}.rawcookedattachment"
+            rm -f "${file}.rawcooked_reversibility_data"
 
             ${valgrind} rawcooked "${file}.mkv" >/dev/null 2>&1
             result=$?

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -89,7 +89,7 @@ void WriteToDisk(uint8_t* Buffer, size_t Buffer_Size, void* Opaque)
     write_to_disk_struct* WriteToDisk_Data = (write_to_disk_struct*)Opaque;
 
     string OutFileName(FFmpeg_Info.empty()?WriteToDisk_Data->FileName:FFmpeg_Info[0].FileName);
-    OutFileName += ".rawcookedattachment";
+    OutFileName += ".rawcooked_reversibility_data";
     FILE* F = fopen(OutFileName.c_str(), (WriteToDisk_Data->IsFirstFile && WriteToDisk_Data->IsFirstFrame)?"wb":"ab");
     fwrite(Buffer, Buffer_Size, 1, F);
     fclose(F);
@@ -348,7 +348,7 @@ int FFmpeg_Command(const char* FileName)
         }
     
     string OutFileName(FFmpeg_Info[0].FileName); //TODO: remove duplicated code
-    OutFileName += ".rawcookedattachment";
+    OutFileName += ".rawcooked_reversibility_data";
 
     string Command;
     Command += "ffmpeg";

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -75,6 +75,9 @@ private:
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionAfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionBeforeData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionFileName);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryName);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryVersion);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_AfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_BeforeData);


### PR DESCRIPTION
Incompatible change (it is expected to be the last one!)

After discussion with some (potential) sponsors, it appears there is a need of flexibility:
- The target and advised (in the future) method is still to have RAWcooked metadata in specific Matroska elements (Segment, Track, BlockGroup); not yet implemented.
- Some people may prefer to have the current implementation (an attached file) for Matroska, or may think to embed the RAWcooked data in MP4 dedicated atom or AVI dedicated chunk.
- Some people may prefer to have a sidecar file

As a result, changes are:
- we clearly separate what is global (Segment), per track (TrackEntry), and per frame (BlockGroup), and [we try to have that official in Matroska specs](https://github.com/Matroska-Org/matroska-specification/pull/223)
- we add an EBML header for "registering" RAWcooked as a EBML Doctype, for standalone files or attachments, so RAWcooked file is easy to detect

I [expanded MediaInfo for parsing RAWcooked files](https://github.com/MediaArea/MediaInfoLib/pull/820), [here](https://gist.github.com/JeromeMartinez/843fdbe31779838bc0a288354b0d52d3) is a [MediaTrace](https://mediaarea.net/MediaTrace) of an [example in our regression tests](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/tree/master/Features/AV_Package/818_DCDM_P3_IA_FIC_000918), 2 video + 2 audio.