### PR TITLE
Attachments support

### DIFF
--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -1,1 +1,1 @@
-Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV/818_OV_0086945.dpx 818_OV_FR_ST/818_OV_FR_ST_0086945.dpx 818_TextlessBGD/818_TextlessBGD_0086160.dpx audio/818_DCP_5point1_20170221.500ms.wav audio/818_Stereo_LtRt_20170329.500ms.wav
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV/818_OV_0086945.dpx 818_OV_FR_ST/818_OV_FR_ST_0086945.dpx 818_TextlessBGD/818_TextlessBGD_0086160.dpx audio/818_DCP_5point1_20170221.500ms.wav audio/818_Stereo_LtRt_20170329.500ms.wav md5deep.md5 audio/md5sum.md5

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -101,6 +101,7 @@ const char* dpx::ErrorMessage()
 dpx::dpx() :
     WriteFileCall(NULL),
     WriteFileCall_Opaque(NULL),
+    IsDetected(false),
     Style(DPX_Style_Max),
     error_message(NULL)
 {
@@ -142,7 +143,7 @@ uint32_t dpx::Get_B4()
 bool dpx::Parse()
 {
     if (Buffer_Size < 1664)
-        return Error("DPX file size");
+        return Error(NULL);
 
     Buffer_Offset = 0;
     uint32_t Magic = Get_B4();
@@ -155,8 +156,9 @@ bool dpx::Parse()
             IsBigEndian = true;
             break;
         default:
-            return Error("DPX header");
+            return Error(NULL);
     }
+    IsDetected = true;
     uint32_t OffsetToImage = Get_X4();
     if (OffsetToImage > Buffer_Size)
         return Error("Offset to image data in bytes");

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -33,6 +33,7 @@ public:
     void*                       WriteFileCall_Opaque;
 
     // Info
+    bool                        IsDetected;
     uint64_t                    Style;
     size_t                      slice_x;
 

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -155,6 +155,7 @@ private:
     vector<trackinfo*>          TrackInfo;
     size_t                      TrackInfo_Pos;
     vector<uint8_t>             ID_to_TrackOrder;
+    string                      AttachedFile_FileName;
     ThreadPool*                 FramesPool;
 
     //Utils


### PR DESCRIPTION
Any file not detected as supported ( = not DPX and not WAV) and relatively small (in order to have e.g. adding a TIFF file, currently not supported, as attachment) is added as attachment, and demuxed during reverse