### PR TITLE
DPX 12-bit non alpha packed enabled

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -26,9 +26,9 @@ Formats/DPX/Flavors/RGB_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit
 Formats/DPX/Flavors/RGB_10_FilledA_LE/image090003.dpx pass
 Formats/DPX/Flavors/RGB_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_noalpha.dpx pass
-Formats/DPX/Flavors/RGB_12_Packed_BE/12bit.dpx fail
-Formats/DPX/Flavors/RGB_12_Packed_BE/af093_ifa2006350_10000086400.dpx fail
-Formats/DPX/Flavors/RGB_12_Packed_BE/RGB_12_bit.dpx fail
+Formats/DPX/Flavors/RGB_12_Packed_BE/12bit.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/af093_ifa2006350_10000086400.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/RGB_12_bit.dpx pass
 Formats/DPX/Flavors/RGB_16F_Packed_BE/RGB_half_float_16_bit.dpx fail
 Formats/DPX/Flavors/RGB_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_noalpha.dpx pass

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -50,7 +50,7 @@ struct dpx_tested
     dpx::style                  Style;
 };
 
-const size_t DPX_Tested_Size = 24;
+const size_t DPX_Tested_Size = 25;
 struct dpx_tested DPX_Tested[DPX_Tested_Size] =
 {
     { RGB       ,  8, Packed , BE, dpx::RGB_8 },
@@ -59,7 +59,7 @@ struct dpx_tested DPX_Tested[DPX_Tested_Size] =
     { RGB       ,  8, MethodA, LE, dpx::RGB_8 },
     { RGB       , 10, MethodA, LE, dpx::RGB_10_FilledA_LE },
     { RGB       , 10, MethodA, BE, dpx::RGB_10_FilledA_BE },
-//    { RGB       , 12, Packed , BE, dpx::RGB_12_Packed_BE }, // Not supported by FFmpeg DPX parser
+    { RGB       , 12, Packed , BE, dpx::RGB_12_Packed_BE },
     { RGB       , 12, MethodA, BE, dpx::RGB_12_FilledA_BE },
     { RGB       , 12, MethodA, LE, dpx::RGB_12_FilledA_LE },
     { RGB       , 16, Packed , BE, dpx::RGB_16_BE },


### PR DESCRIPTION
Hi,

I think this is the split version of https://github.com/MediaArea/RAWcooked/pull/30 that ignores alpha.