### PR TITLE
 Keep the top directory name during revert when there are subdirs 

### DIFF
--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -1,21 +1,7 @@
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV/818_OV_0086945.dpx 818_OV_FR_ST/818_OV_FR_ST_0086945.dpx 818_TextlessBGD/818_TextlessBGD_0086160.dpx audio/818_DCP_5point1_20170221.500ms.wav audio/818_Stereo_LtRt_20170329.500ms.wav md5deep.md5 audio/md5sum.md5
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ../818_DCDM_P3_IA_FIC_000918/
-Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ../818_DCDM_P3_IA_FIC_000918
-Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ./
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918 .
 Features/AV_Package 818_DCDM_P3_IA_FIC_000918/
-Features/AV_Package 818_DCDM_P3_IA_FIC_000918
 Features/AV_Package HavingReels01-02/
-Features/AV_Package HavingReels01-02
-Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02/
-Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02
-Features/AV_Package/HavingReels01-02 ../HavingReels01-02/
-Features/AV_Package/HavingReels01-02 ../HavingReels01-02
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM/
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02/
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX/
-Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX
 Features/AV_Package HavingReels1-10/

--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -6,3 +6,16 @@ Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ./
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918 .
 Features/AV_Package 818_DCDM_P3_IA_FIC_000918/
 Features/AV_Package 818_DCDM_P3_IA_FIC_000918
+Features/AV_Package HavingReels01-02/
+Features/AV_Package HavingReels01-02
+Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02/
+Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02
+Features/AV_Package/HavingReels01-02 ../HavingReels01-02/
+Features/AV_Package/HavingReels01-02 ../HavingReels01-02
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX
+Features/AV_Package HavingReels1-10/

--- a/Project/GNU/CLI/test/test2full.txt
+++ b/Project/GNU/CLI/test/test2full.txt
@@ -1,0 +1,21 @@
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV/818_OV_0086945.dpx 818_OV_FR_ST/818_OV_FR_ST_0086945.dpx 818_TextlessBGD/818_TextlessBGD_0086160.dpx audio/818_DCP_5point1_20170221.500ms.wav audio/818_Stereo_LtRt_20170329.500ms.wav md5deep.md5 audio/md5sum.md5
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 818_OV
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ../818_DCDM_P3_IA_FIC_000918/
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ../818_DCDM_P3_IA_FIC_000918
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 ./
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918 .
+Features/AV_Package 818_DCDM_P3_IA_FIC_000918/
+Features/AV_Package 818_DCDM_P3_IA_FIC_000918
+Features/AV_Package HavingReels01-02/
+Features/AV_Package HavingReels01-02
+Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02/
+Features/AV_Package/HavingReels01-02 SubDirHavingReels01-02
+Features/AV_Package/HavingReels01-02 ../HavingReels01-02/
+Features/AV_Package/HavingReels01-02 ../HavingReels01-02
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02 FILM
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX/
+Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX
+Features/AV_Package HavingReels1-10/

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -554,12 +554,32 @@ int main(int argc, char* argv[])
     }
 
     vector<string> Files;
+    bool HasAtLeastOneDir = false;
+    bool HasAtLeastOneFile = false;
     for (int i = 1; i < argc; i++)
     {
         if (IsDir(Args[i].c_str()))
+        {
+            if (HasAtLeastOneDir)
+            {
+                cout << "Input contains several directories, is it intended? Please contact info@mediaarea.net if you want support of such input.\n";
+                return 1;
+            }
+            HasAtLeastOneDir = true;
+
             DetectSequence_FromDir(Args[i].c_str(), Files);
+        }
         else
+        {
+            HasAtLeastOneFile = true;
+
             Files.push_back(Args[i]);
+        }
+    }
+    if (HasAtLeastOneDir && HasAtLeastOneFile)
+    {
+        cout << "Input contains a mix of directories and files, is it intended? Please contact info@mediaarea.net if you want support of such input.\n";
+        return 1;
     }
 
     // RAWcooked file name
@@ -574,6 +594,21 @@ int main(int argc, char* argv[])
     {
         size_t Path_Pos;
         DetectPathPos(Files[i], Path_Pos);
+        if (Path_Pos_Global > Path_Pos)
+            Path_Pos_Global = Path_Pos;
+    }
+
+    // Keeping directory name if a directory is used even if there are subdirs
+    if (HasAtLeastOneDir)
+    {
+        size_t Path_Pos = Args[1].size();
+        if (Args[1][Args[1].size() - 1] == '/' || Args[1][Args[1].size() - 1] == '\\')
+            Path_Pos--;
+        if (Path_Pos)
+            Path_Pos = Args[1].find_last_of("/\\", Path_Pos - 1);
+        if (Path_Pos == string::npos)
+            Path_Pos = 0;
+
         if (Path_Pos_Global > Path_Pos)
             Path_Pos_Global = Path_Pos;
     }

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -458,12 +458,17 @@ int ParseFile(vector<string>& AllFiles, size_t AllFiles_Pos)
 int FFmpeg_Command(const char* FileName)
 {
     // Multiple slices number currently not supported
-    for (size_t i = 1; i < FFmpeg_Info.size(); i++)
-        if (!FFmpeg_Info[i].Slices.empty() && FFmpeg_Info[i].Slices != FFmpeg_Info[0].Slices)
+    string Slices;
+    for (size_t i = 0; i < FFmpeg_Info.size(); i++)
+    {
+        if (Slices.empty() && !FFmpeg_Info[i].Slices.empty())
+            Slices = FFmpeg_Info[i].Slices;
+        if (!FFmpeg_Info[i].Slices.empty() && FFmpeg_Info[i].Slices != Slices)
         {
             cerr << "Untested multiple slices counts, please contact info@mediaarea.net if you want support of such file\n";
             return 1;
         }
+    }
 
     string Command;
     Command += "ffmpeg";
@@ -500,8 +505,8 @@ int FFmpeg_Command(const char* FileName)
         MapPos++;
 
     // Output
-    if (!FFmpeg_Info[0].Slices.empty())
-        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices " + FFmpeg_Info[0].Slices;
+    if (!Slices.empty())
+        Command += " -c:v ffv1 -level 3 -coder 1 -context 0 -g 1 -slices " + Slices;
     Command += " -c:a copy";
     for (size_t i = 0; i < FFmpeg_Attachments.size(); i++)
     {


### PR DESCRIPTION
if e.g. directory with files only in "rawcooked Dir/SubDir/SubDir2", "rawcooked Dir" keeps "Dir/SubDir/SubDir2" during revert.
Includes tests on directories with several reels (each real is considered as a track for the moment, does not prevent reversibility) [just added](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/commit/441e619ad142623e3c4a6131e1f82c934456f10f).
Includes a fix in case a WAV file comes first in the list of files in a directory.