### PR TITLE
Ignore 0 byte files

### DIFF
--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -5,3 +5,5 @@ Features/AV_Package/818_DCDM_P3_IA_FIC_000918 .
 Features/AV_Package 818_DCDM_P3_IA_FIC_000918/
 Features/AV_Package HavingReels01-02/
 Features/AV_Package HavingReels1-10/
+Features/EmptyContent EmptyFiles/
+Features/EmptyContent EmptyFolders/

--- a/Project/GNU/CLI/test/test2full.txt
+++ b/Project/GNU/CLI/test/test2full.txt
@@ -19,3 +19,5 @@ Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM FILM_REEL_02
 Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX/
 Features/AV_Package/HavingReels01-02/SubDirHavingReels01-02/FILM/FILM_REEL_02 FILM_REEL_02_DPX
 Features/AV_Package HavingReels1-10/
+Features/EmptyContent EmptyFiles/
+Features/EmptyContent EmptyFolders/

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -427,10 +427,13 @@ int ParseFile(vector<string>& AllFiles, size_t AllFiles_Pos)
                 exit(1);
             }
 
-            ffmpeg_attachment_struct Attachment;
-            Attachment.FileName_In = Name;
-            Attachment.FileName_Out = Name.substr(Path_Pos_Global);
-            FFmpeg_Attachments.push_back(Attachment);
+            if (Buffer_Size) // Ignoring file with size of 0
+            {
+                ffmpeg_attachment_struct Attachment;
+                Attachment.FileName_In = Name;
+                Attachment.FileName_Out = Name.substr(Path_Pos_Global);
+                FFmpeg_Attachments.push_back(Attachment);
+            }
         }
         else
         {


### PR DESCRIPTION
Partially resolves https://github.com/MediaArea/RAWcooked/issues/56 by ignoring 0 byte files.