### PR TITLE
Adapt slice count to the width/height/bitdepth of input

### DIFF
--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -394,7 +394,7 @@ int ParseFile(vector<string>& AllFiles, size_t AllFiles_Pos)
             if (WriteToDisk_Data.IsFirstFrame)
             {
                 stringstream t;
-                t << DPX.slice_x * DPX.slice_x;
+                t << DPX.slice_x * DPX.slice_y;
                 slices = t.str();
             }
             WriteToDisk_Data.IsFirstFrame = false;

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -36,6 +36,7 @@ public:
     bool                        IsDetected;
     uint64_t                    Style;
     size_t                      slice_x;
+    size_t                      slice_y;
 
     // Error message
     const char*                 ErrorMessage();


### PR DESCRIPTION
Idea:
- have some SIMD compatible slice count (e.g. AVX-512 has 16 32-bit blocks, let's take multiples of 16)
- each slice has around 256 KiB of data, there is a similar risk of losing 1 LTO block (correction code per block, to be confirmed but looks like a 256 KiB block size is classic)

This leads to:
SD: 16 slices (10-bit) or 32 slices (16-bit)
HD/2K: 64 slices (10-bit) or 128 slices (16-bit)
UHD/4K: 256 slices (10-bit) or 512 slices (16-bit)