### PR TITLE
Set framerate in FFmpeg command line

### DIFF
--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -37,6 +37,7 @@ public:
     uint64_t                    Style;
     size_t                      slice_x;
     size_t                      slice_y;
+    string*                     FrameRate;
 
     // Error message
     const char*                 ErrorMessage();
@@ -76,6 +77,7 @@ private:
     uint32_t                    Get_L4();
     uint32_t                    Get_B4();
     uint32_t                    Get_X4() { return IsBigEndian ? Get_B4() : Get_L4(); }
+    double                      Get_XF4();
 
     // Error message
     const char*                 error_message;


### PR DESCRIPTION
From user input or from DPX.
DPX has 2 frame rates, raising an error if they are not 0 and not same.

Test is on the first DPX only.