### PR TITLE
Launch FFmpeg command directly

### DIFF
--- a/Project/GNU/CLI/test/notfound.sh
+++ b/Project/GNU/CLI/test/notfound.sh
@@ -4,7 +4,7 @@ PATH="${PWD}:$PATH"
 
 rcode=0
 
-stderr=$(${valgrind} rawcooked DoesNotExist/NotFound.dpx 2>&1 >/dev/null)
+stderr=$(${valgrind} rawcooked -d DoesNotExist/NotFound.dpx 2>&1 >/dev/null)
 result=$?
 
 # check valgrind

--- a/Project/GNU/CLI/test/test1.sh
+++ b/Project/GNU/CLI/test/test1.sh
@@ -36,7 +36,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        cmdline=$(${valgrind} rawcooked "${file}" 2>stderr)
+        cmdline=$(${valgrind} rawcooked -d "${file}" 2>stderr)
         result=$?
         stderr="$(<stderr)"
         rm -f stderr

--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -42,7 +42,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-            cmdline=$(${valgrind} rawcooked ${files} 2>/dev/null)
+            cmdline=$(${valgrind} rawcooked -d ${files} 2>/dev/null)
             result=$?
 
             if [ "${file: -1}" == "/" ] ; then

--- a/Project/GNU/CLI/test/test3.sh
+++ b/Project/GNU/CLI/test/test3.sh
@@ -23,7 +23,7 @@ while read line ; do
     test=$(basename "${path}")
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        cmdline=$(${valgrind} rawcooked "${file}" 2>stderr)
+        cmdline=$(${valgrind} rawcooked -d "${file}" 2>stderr)
         result=$?
         stderr="$(<stderr)"
         rm -f stderr


### PR DESCRIPTION
With options for displaying FFmpeg command or setting the FFmpeg binary name

Regression tests keep using the method displaying FFmpeg command and launching manually.