### PR TITLE
Remove the temporary file after FFmpeg command

### DIFF
--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -622,6 +622,11 @@ int FFmpeg_Command(const char* FileName)
             #endif
             return Value;
         }
+
+        // Delete the temporary file
+        int Result = remove(rawcooked_reversibility_data_FileName.c_str());
+        if (Result)
+            cerr << "Error: can not remove temporary file " << rawcooked_reversibility_data_FileName << endl;
     }
 
     return 0;


### PR DESCRIPTION
Only if RAWcooked launches FFmpeg, else the user is still in charge to delete the file.