### PR TITLE
Path separator indication in reversibility file and forced to "/"

### DIFF
--- a/Doc/File_Stucture.md
+++ b/Doc/File_Stucture.md
@@ -68,6 +68,11 @@ It may contain information about the RAWcooked reversibility data writing librar
 
 #### LibraryVersion
 
+#### PathSeparator
+
+Indicate the path separator of file names.  
+If not present, considered as "/".  
+
 ### RawCookedTrack
 
 A "RawCookedTrack" element contains information about a track.  

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -190,6 +190,7 @@ ELEMENT_END()
 ELEMENT_BEGIN(Segment_Attachments_AttachedFile_FileData_RawCookedSegment)
 ELEMENT_VOID(      70, Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryName)
 ELEMENT_VOID(      71, Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryVersion)
+ELEMENT_VOID(      72, Segment_Attachments_AttachedFile_FileData_RawCookedSegment_PathSeparator)
 ELEMENT_END()
 
 ELEMENT_BEGIN(Segment_Attachments_AttachedFile_FileData_RawCookedTrack)
@@ -536,6 +537,17 @@ void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedSegment_Librar
 {
     RAWcooked_LibraryVersion = string((const char*)Buffer + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
     RejectIncompatibleVersions();
+}
+
+//---------------------------------------------------------------------------
+void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedSegment_PathSeparator()
+{
+    string RAWcooked_PathSeparator = string((const char*)Buffer + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
+    if (RAWcooked_PathSeparator != "/")
+    {
+        std::cerr << "Path separator not / is not supported, exiting" << std::endl;
+        exit(1);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -75,6 +75,7 @@ private:
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryVersion);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_PathSeparator);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_AfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_BeforeData);

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -44,6 +44,7 @@ static const uint32_t Name_RawCooked_FileSHA256 = 0x22;
 // Global information
 static const uint32_t Name_RawCooked_LibraryName = 0x70;
 static const uint32_t Name_RawCooked_LibraryVersion = 0x71;
+static const uint32_t Name_RawCooked_PathSeparator = 0x72;
 // Parameters
 static const char* DocType = "rawcooked";
 static const uint8_t DocTypeVersion = 1;
@@ -130,6 +131,17 @@ rawcooked::~rawcooked()
 //---------------------------------------------------------------------------
 void rawcooked::Parse()
 {
+    // Cross-platform support
+    // RAWcooked file format supports setting of the path separator but
+    // we currently set all to "/", which is supported by both Windows and Unix based platforms
+    // On Windows, we convert "\" to "/" as both are considered as path separators and Unix-based  systems don't consider "\" as a path separator
+    // If not doing this, files are not considered as in a sub-directory when encoded with a Windows platform then decoded with a Unix-based platform.
+    #if defined(_WIN32) || defined(_WINDOWS)
+        string::size_type i = 0;
+        while ((i = FileNameDPX.find('\\', i)) != string::npos)
+            FileNameDPX[i++] = '/';
+    #endif
+
     // Create or Use mask
     uint8_t* FileName = (uint8_t*)FileNameDPX.c_str();
     size_t FileName_Size = FileNameDPX.size();


### PR DESCRIPTION
Cross-platform support.

RAWcooked file format supports setting of the path separator but we currently set all to "/", which is supported by both Windows and Unix based platforms
On Windows, we convert "\" to "/" as both are considered as path separators and Unix based systems don't consider "\" as a path separator
If not doing this, files are not considered as in a sub-directory when encoded with a Windows platform then decoded with a Unix-based platform.

This permits that even if we don't implement full support of a different path separators right now, we are future-proof with the stored files in case the path separator changes in the future, as stored files indicate the path separator used.

Path separator has a default in RAWcooked specification, so we don't store it in current version of the writing tool.