### PR TITLE
We don't need to store path separator at first position of a file name

### DIFF
--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -260,8 +260,7 @@ int input::AnalyzeInputs(global& Global)
             Path_Pos--;
         if (Path_Pos)
             Path_Pos = Global.Inputs[0].find_last_of("/\\", Path_Pos - 1);
-        if (Path_Pos == string::npos)
-            Path_Pos = 0;
+        Path_Pos++;
 
         if (Global.Path_Pos_Global > Path_Pos)
             Global.Path_Pos_Global = Path_Pos;


### PR DESCRIPTION
File names are relatives to the input file name