### PR TITLE
 Message if FFV1v0/1 is requested without explicitly requesting 1 slice/frame

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -262,7 +262,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
 }
 
 //---------------------------------------------------------------------------
-void global::SetDefaults()
+int global::SetDefaults()
 {
     // Container format
     if (OutputOptions.find("f") == OutputOptions.end())
@@ -289,5 +289,18 @@ void global::SetDefaults()
             OutputOptions["level"] = "3"; // FFV1 v3
         if (OutputOptions.find("slicecrc") == OutputOptions.end())
             OutputOptions["slicecrc"] = "1"; // Slice CRC on
+
+        // Check incompatible options
+        if (OutputOptions["level"] == "0" || OutputOptions["level"] == "1")
+        {
+            map<string, string>::iterator slices = OutputOptions.find("slices");
+            if (slices == OutputOptions.end() || slices->second != "1")
+            {
+                cerr << "\" -level " << OutputOptions["level"] << "\" does not permit slices, is it intended ? if so, add \" -slices 1\" to the command." << endl;
+                return 1;
+            }
+        }
     }
+
+    return 0;
 }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -35,7 +35,7 @@ public:
 
     // Options
     int ManageCommandLine(const char* argv[], int argc);
-    void SetDefaults();
+    int SetDefaults();
 
 private:
     int SetOption(const char* argv[], int& i, int argc);

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -28,7 +28,8 @@ int output::Process(global& Global)
 int output::FFmpeg_Command(const char* FileName, global& Global)
 {
     // Defaults
-    Global.SetDefaults();
+    if (int Value = Global.SetDefaults())
+        return Value;
     if (Global.OutputOptions.find("slices") == Global.OutputOptions.end())
     {
         // Slice count depends on frame size


### PR DESCRIPTION
Fix for https://github.com/MediaArea/RAWcooked/issues/103, showing a more explicit message (user must explicitly request 1 slice/frame if FFV1 v0 or v1 is requested in order to be sure that it is what is wanted).