### PR TITLE
Block compression of files by default

### DIFF
--- a/Project/GNU/CLI/test/test1.sh
+++ b/Project/GNU/CLI/test/test1.sh
@@ -42,7 +42,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        cmdline=$(${valgrind} rawcooked -d "${file}" 2>stderr)
+        cmdline=$(${valgrind} rawcooked --file -d "${file}" 2>stderr)
         result=$?
         stderr="$(<stderr)"
         rm -f stderr
@@ -107,7 +107,7 @@ while read line ; do
             continue
         fi
 
-        ${valgrind} rawcooked "${file}.mkv" >/dev/null 2>&1
+        ${valgrind} rawcooked --file "${file}.mkv" >/dev/null 2>&1
         result=$?
 
         # check valgrind

--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -42,7 +42,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-            cmdline=$(${valgrind} rawcooked -d ${files} 2>/dev/null)
+            cmdline=$(${valgrind} rawcooked --file -d ${files} 2>/dev/null)
             result=$?
 
             if [ "${file: -1}" == "/" ] ; then
@@ -79,7 +79,7 @@ while read line ; do
             fi
             rm -f "${file}.rawcooked_reversibility_data"
 
-            ${valgrind} rawcooked "${file}.mkv" >/dev/null 2>&1
+            ${valgrind} rawcooked --file "${file}.mkv" >/dev/null 2>&1
             result=$?
             echo $result
             # check valgrind

--- a/Project/GNU/CLI/test/test3.sh
+++ b/Project/GNU/CLI/test/test3.sh
@@ -23,7 +23,7 @@ while read line ; do
     test=$(basename "${path}")
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        cmdline=$(${valgrind} rawcooked -d "${file}" 2>stderr)
+        cmdline=$(${valgrind} rawcooked --file -d "${file}" 2>stderr)
         result=$?
         stderr="$(<stderr)"
         rm -f stderr

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -50,6 +50,13 @@ int global::SetDisplayCommand()
 }
 
 //---------------------------------------------------------------------------
+int global::SetAcceptFiles()
+{
+    AcceptFiles = true;
+    return 0;
+}
+
+//---------------------------------------------------------------------------
 int Error_NotTested(const char* Option1, const char* Option2 = NULL)
 {
     cerr << "Option " << Option1;
@@ -200,6 +207,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
 
     AttachmentMaxSize = (size_t)-1;
     DisplayCommand = false;
+    AcceptFiles = false;
 
     for (int i = 1; i < argc; i++)
     {
@@ -232,6 +240,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
         else if ((strcmp(argv[i], "--display-command") == 0 || strcmp(argv[i], "-d") == 0))
         {
             int Value = SetDisplayCommand();
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--file") == 0)
+        {
+            int Value = SetAcceptFiles();
             if (Value)
                 return Value;
         }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -28,6 +28,7 @@ public:
     string                      OutputFileName;
     string                      BinName;
     bool                        DisplayCommand;
+    bool                        AcceptFiles;
 
     // Intermediate info
     size_t                      Path_Pos_Global;
@@ -42,6 +43,7 @@ private:
     int SetOutputFileName(const char* FileName);
     int SetBinName(const char* FileName);
     int SetDisplayCommand();
+    int SetAcceptFiles();
 };
 
 #endif

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -90,6 +90,8 @@ ReturnValue Help(const char* Name)
     cout << "              Note: Not yet implemented for decoding." << endl;
     cout << endl;
     cout << "INPUT RELATED OPTIONS" << endl;
+    cout << "       --file" << endl;
+    cout << "              Unlock compression of files (e.g. a .dpx or .wav)." << endl;
     cout << "       -framerate value" << endl;
     cout << "              Force video frame rate to value." << endl;
     cout << "              Default value is the one found in the image files if  available," << endl;

--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -231,6 +231,11 @@ int input::AnalyzeInputs(global& Global)
         cerr << "Input contains a mix of directories and files, is it intended? Please contact info@mediaarea.net if you want support of such input.\n";
         return 1;
     }
+    if (HasAtLeastOneFile && !Global.AcceptFiles)
+    {
+        cerr << "Input is a file so directory will not be handled as a whole.\nConfirm that this is what you want to do by adding \" --file\" to the command.\n";
+        return 1;
+    }
 
     if (Files.empty())
     {

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -57,6 +57,9 @@ Default name is \fI${Input}.rawcooked_reversibility_data\fR
 \fBNote:\fR Not yet implemented for decoding.
 .SS INPUT RELATED OPTIONS
 .TP
+.B \-\-file
+Unlock compression of files (e.g. a .dpx or .wav).
+.TP
 .B \-framerate \fIvalue
 Force video frame rate to \fIvalue\fR.
 .br


### PR DESCRIPTION
Need an explicit option for compression files.
Because a misuse is possible (user may think that the whole directory is backuped)