### PR TITLE
Information about input

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -152,6 +152,18 @@ int global::SetOption(const char* argv[], int& i, int argc)
         }
         return Error_NotTested(argv[i - 1], argv[i]);
     }
+    if (!strcmp(argv[i], "-loglevel"))
+    {
+        if (++i >= argc)
+            return Error_NotTested(argv[i - 1]);
+        if (!strcmp(argv[i], "error")
+         || !strcmp(argv[i], "warning"))
+        {
+            OutputOptions["loglevel"] = argv[i];
+            return 0;
+        }
+        return Error_NotTested(argv[i - 1], argv[i]);
+    }
     if (!strcmp(argv[i], "-slicecrc"))
     {
         if (++i >= argc)
@@ -197,6 +209,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
     AttachmentMaxSize = (size_t)-1;
     DisplayCommand = false;
     AcceptFiles = false;
+    Quiet = false;
 
     for (int i = 1; i < argc; i++)
     {
@@ -219,7 +232,9 @@ int global::ManageCommandLine(const char* argv[], int argc)
             }
         }
         else if ((strcmp(argv[i], "--attachment-max-size") == 0 || strcmp(argv[i], "-s") == 0) && i + 1 < argc)
+        {
             AttachmentMaxSize = atoi(argv[++i]);
+        }
         else if ((strcmp(argv[i], "--bin-name") == 0 || strcmp(argv[i], "-b") == 0) && i + 1 < argc)
         {
             int Value = SetBinName(argv[++i]);
@@ -255,6 +270,10 @@ int global::ManageCommandLine(const char* argv[], int argc)
             int Value = SetOutputFileName(argv[++i]);
             if (Value)
                 return Value;
+        }
+        else if (strcmp(argv[i], "--quiet") == 0)
+        {
+            Quiet = true;
         }
         else if ((strcmp(argv[i], "--rawcooked-file-name") == 0 || strcmp(argv[i], "-r") == 0) && i + 1 < argc)
             rawcooked_reversibility_data_FileName = argv[++i];

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -31,6 +31,7 @@ public:
     bool                        AcceptFiles;
     bool                        HasAtLeastOneDir;
     bool                        HasAtLeastOneFile;
+    bool                        Quiet;
 
     // Intermediate info
     size_t                      Path_Pos_Global;

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -89,6 +89,9 @@ ReturnValue Help(const char* Name)
     cout << "              the  output  A/V  file during the encoding, this file is deleted" << endl;
     cout << "              after encoding." << endl;
     cout << "              Note: Not yet implemented for decoding." << endl;
+    cout << "       --quiet" << endl;
+    cout << "              Do not show information related to RAWcooked." << endl;
+    cout << "              Encoder application may need an additional option." << endl;
     cout << endl;
     cout << "INPUT RELATED OPTIONS" << endl;
     cout << "       --file" << endl;

--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -60,7 +60,7 @@ void DetectPathPos(const string &Name, size_t& Path_Pos)
 }
 
 //---------------------------------------------------------------------------
-void input::DetectSequence(size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber)
+void input::DetectSequence(size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber)
 {
     string FN(Files[AllFiles_Pos]);
     string Path;
@@ -90,6 +90,7 @@ void input::DetectSequence(size_t AllFiles_Pos, vector<string>& RemovedFiles, si
         for (;;)
         {
             RemovedFiles.push_back(Path + Before + FN + After);
+            FileName_EndNumber = FN;
             size_t i = FN.size() - 1;
             for (;;)
             {

--- a/Source/CLI/Input.h
+++ b/Source/CLI/Input.h
@@ -24,7 +24,7 @@ public:
 
     // Commands
     int AnalyzeInputs(global& Global);
-    void DetectSequence(size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber);
+    void DetectSequence(size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber);
 };
 
 #endif

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -51,6 +51,7 @@ int ParseFile(size_t Files_Pos)
         if (M.OutputDirectoryName.find_last_of("/\\") != M.OutputDirectoryName.size() - 1)
             M.OutputDirectoryName += PathSeparator;
     }
+    M.Quiet = Global.Quiet;
     M.Buffer = FileMap.Buffer;
     M.Buffer_Size = FileMap.Buffer_Size;
     M.Parse();
@@ -58,6 +59,8 @@ int ParseFile(size_t Files_Pos)
     vector<string> RemovedFiles;
     string FileName_Template;
     string FileName_StartNumber;
+    string FileName_EndNumber;
+    string Flavor;
     string Slices;
     string FrameRate;
 
@@ -83,13 +86,14 @@ int ParseFile(size_t Files_Pos)
         if (RIFF.IsDetected)
         {
             RemovedFiles.push_back(Name);
+            Flavor = RIFF.Flavor_String((riff::style)RIFF.Style);
         }
     }
 
     dpx DPX;
     if (!M.IsDetected && !RIFF.IsDetected)
     {
-        Input.DetectSequence(Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber);
+        Input.DetectSequence(Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber);
 
         size_t i = 0;
         for (;;)
@@ -120,6 +124,11 @@ int ParseFile(size_t Files_Pos)
                 break;
             Name = RemovedFiles[i];
             FileMap.Open_ReadMode(Name);
+        }
+
+        if (DPX.IsDetected)
+        {
+            Flavor = DPX.Flavor_String((dpx::style)DPX.Style);
         }
     }
 
@@ -164,9 +173,11 @@ int ParseFile(size_t Files_Pos)
             Stream.FileName = RemovedFiles[0];
             if (!FileName_StartNumber.empty() && !FileName_Template.empty())
             {
-                Stream.FileName_StartNumber = FileName_StartNumber;
                 Stream.FileName_Template = FileName_Template;
+                Stream.FileName_StartNumber = FileName_StartNumber;
+                Stream.FileName_EndNumber = FileName_EndNumber;
             }
+            Stream.Flavor = Flavor;
 
             Stream.Slices = Slices;
             if (!Slices.empty() && FrameRateFromOptions == Global.VideoInputOptions.end())
@@ -176,7 +187,7 @@ int ParseFile(size_t Files_Pos)
         }
 
     }
-    else
+    else if (!Global.Quiet)
         cout << "Files are in " << M.OutputDirectoryName << endl;
 
     FileMap.Close();

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -76,6 +76,22 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     // Input
     for (size_t i = 0; i < Streams.size(); i++)
     {
+        // Info
+        if (!Global.Quiet)
+        {
+            cerr << "Track " << i + 1 << ':' << endl;
+            if (Streams[i].FileName_Template.empty())
+            {
+                cerr << "  " << Streams[i].FileName.substr(((Global.Inputs.size() == 1 && Global.Inputs[0].size() < Streams[i].FileName.size()) ? Global.Inputs[0].size() : Streams[i].FileName.find_last_of("/\\")) + 1) << endl;
+            }
+            else
+            {
+                cerr << "  " << Streams[i].FileName_Template.substr(((Global.Inputs.size() == 1 && Global.Inputs[0].size() < Streams[i].FileName.size()) ? Global.Inputs[0].size() : Streams[i].FileName.find_last_of("/\\")) + 1) << endl;
+                cerr << " (" << Streams[i].FileName_StartNumber << " --> " << Streams[i].FileName_EndNumber << ')' << endl;
+            }
+            cerr << "  " << Streams[i].Flavor << endl;
+        }
+
         if (!Streams[i].Slices.empty())
         {
             for (map<string, string>::iterator Option = Global.VideoInputOptions.begin(); Option != Global.VideoInputOptions.end(); Option++)
@@ -115,6 +131,14 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
         Command += " -" + Option->first + ' ' + Option->second;
     for (size_t i = 0; i < Attachments.size(); i++)
     {
+        // Info
+        if (!Global.Quiet)
+        {
+            if (!i)
+                cerr << "Attachments:" << endl;
+            cerr << "  " << Attachments[i].FileName_Out.substr(Attachments[i].FileName_Out.find_first_of("/\\")+1) << endl;
+        }
+
         stringstream t;
         t << MapPos++;
         Command += " -attach \"" + Attachments[i].FileName_In + "\" -metadata:s:" + t.str() + " mimetype=application/octet-stream -metadata:s:" + t.str() + " \"filename=" + Attachments[i].FileName_Out + "\"";
@@ -135,6 +159,12 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
         Command += " -f matroska \"";
         Command += Global.OutputFileName;
         Command += '\"';
+    }
+
+    // Info
+    if (!Global.Quiet)
+    {
+        cerr << endl;
     }
 
     if (Global.DisplayCommand)

--- a/Source/CLI/Output.h
+++ b/Source/CLI/Output.h
@@ -23,6 +23,8 @@ struct stream
     string                      FileName;
     string                      FileName_Template;
     string                      FileName_StartNumber;
+    string                      FileName_EndNumber;
+    string                      Flavor;
     string                      Slices;
     string                      FrameRate;
 };

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -55,6 +55,11 @@ Default name is \fI${Input}.rawcooked_reversibility_data\fR
 \fBNote:\fR If the \fBRAWcooked\fR reversibility data file is included in the output A/V file during the encoding, this file is deleted after encoding.
 .br
 \fBNote:\fR Not yet implemented for decoding.
+.TP
+.B \-\-quiet
+Do not show information related to RAWcooked.
+.br
+External encoder/decoder may need an additional option.
 .SS INPUT RELATED OPTIONS
 .TP
 .B \-\-file

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -15,74 +15,45 @@ using namespace std;
 
 //---------------------------------------------------------------------------
 // Tested cases
-enum endianess
-{
-    LE,
-    BE,
-};
-enum descriptor
-{
-    R           =   1,
-    G           =   2,
-    B           =   3,
-    A           =   4,
-    Y           =   6,
-    ColorDiff   =   7,
-    Z           =   8,
-    Composite   =   9,
-    RGB         =  50,
-    RGBA        =  51,
-    ABGR        =  52,
-    CbYCrY      = 100,
-    CbYACrYA    = 101,
-    CbYCr       = 102,
-    CbYCrA      = 103,
-};
-enum packing
-{
-    Packed,
-    MethodA,
-    MethodB,
-};
-
 struct dpx_tested
 {
-    descriptor                  Descriptor;
+    dpx::encoding               Encoding;
+    dpx::descriptor             Descriptor;
     uint8_t                     BitDepth;
-    packing                     Packing;
-    endianess                   Endianess;
+    dpx::packing                Packing;
+    dpx::endianess              Endianess;
     dpx::style                  Style;
 };
 
 const size_t DPX_Tested_Size = 26;
 struct dpx_tested DPX_Tested[DPX_Tested_Size] =
 {
-    { RGB       ,  8, Packed , BE, dpx::RGB_8 },
-    { RGB       ,  8, Packed , LE, dpx::RGB_8 },
-    { RGB       ,  8, MethodA, BE, dpx::RGB_8 },
-    { RGB       ,  8, MethodA, LE, dpx::RGB_8 },
-    { RGB       , 10, MethodA, LE, dpx::RGB_10_FilledA_LE },
-    { RGB       , 10, MethodA, BE, dpx::RGB_10_FilledA_BE },
-    { RGB       , 12, Packed , BE, dpx::RGB_12_Packed_BE },
-    { RGB       , 12, MethodA, BE, dpx::RGB_12_FilledA_BE },
-    { RGB       , 12, MethodA, LE, dpx::RGB_12_FilledA_LE },
-    { RGB       , 16, Packed , BE, dpx::RGB_16_BE },
-    { RGB       , 16, Packed , LE, dpx::RGB_16_LE },
-    { RGB       , 16, MethodA, BE, dpx::RGB_16_BE },
-    { RGB       , 16, MethodA, LE, dpx::RGB_16_LE },
-    { RGBA      ,  8, Packed , BE, dpx::RGBA_8 },
-    { RGBA      ,  8, Packed , LE, dpx::RGBA_8 },
-    { RGBA      ,  8, MethodA, BE, dpx::RGBA_8 },
-    { RGBA      ,  8, MethodA, LE, dpx::RGBA_8 },
-    { RGBA      , 10, MethodA, LE, dpx::RGBA_10_FilledA_LE },
-    { RGBA      , 10, MethodA, BE, dpx::RGBA_10_FilledA_BE },
-    { RGBA      , 12, Packed , BE, dpx::RGBA_12_Packed_BE },
-    { RGBA      , 12, MethodA, BE, dpx::RGBA_12_FilledA_BE },
-    { RGBA      , 12, MethodA, LE, dpx::RGBA_12_FilledA_LE },
-    { RGBA      , 16, Packed , BE, dpx::RGBA_16_BE },
-    { RGBA      , 16, Packed , LE, dpx::RGBA_16_LE },
-    { RGBA      , 16, MethodA, BE, dpx::RGBA_16_BE },
-    { RGBA      , 16, MethodA, LE, dpx::RGBA_16_LE },
+    { dpx::Raw  , dpx::RGB      ,  8, dpx::Packed , dpx::BE, dpx::Raw_RGB_8 },
+    { dpx::Raw  , dpx::RGB      ,  8, dpx::Packed , dpx::LE, dpx::Raw_RGB_8 },
+    { dpx::Raw  , dpx::RGB      ,  8, dpx::MethodA, dpx::BE, dpx::Raw_RGB_8 },
+    { dpx::Raw  , dpx::RGB      ,  8, dpx::MethodA, dpx::LE, dpx::Raw_RGB_8 },
+    { dpx::Raw  , dpx::RGB      , 10, dpx::MethodA, dpx::LE, dpx::Raw_RGB_10_FilledA_LE },
+    { dpx::Raw  , dpx::RGB      , 10, dpx::MethodA, dpx::BE, dpx::Raw_RGB_10_FilledA_BE },
+    { dpx::Raw  , dpx::RGB      , 12, dpx::Packed , dpx::BE, dpx::Raw_RGB_12_Packed_BE },
+    { dpx::Raw  , dpx::RGB      , 12, dpx::MethodA, dpx::BE, dpx::Raw_RGB_12_FilledA_BE },
+    { dpx::Raw  , dpx::RGB      , 12, dpx::MethodA, dpx::LE, dpx::Raw_RGB_12_FilledA_LE },
+    { dpx::Raw  , dpx::RGB      , 16, dpx::Packed , dpx::BE, dpx::Raw_RGB_16_BE },
+    { dpx::Raw  , dpx::RGB      , 16, dpx::Packed , dpx::LE, dpx::Raw_RGB_16_LE },
+    { dpx::Raw  , dpx::RGB      , 16, dpx::MethodA, dpx::BE, dpx::Raw_RGB_16_BE },
+    { dpx::Raw  , dpx::RGB      , 16, dpx::MethodA, dpx::LE, dpx::Raw_RGB_16_LE },
+    { dpx::Raw  , dpx::RGBA     ,  8, dpx::Packed , dpx::BE, dpx::Raw_RGBA_8 },
+    { dpx::Raw  , dpx::RGBA     ,  8, dpx::Packed , dpx::LE, dpx::Raw_RGBA_8 },
+    { dpx::Raw  , dpx::RGBA     ,  8, dpx::MethodA, dpx::BE, dpx::Raw_RGBA_8 },
+    { dpx::Raw  , dpx::RGBA     ,  8, dpx::MethodA, dpx::LE, dpx::Raw_RGBA_8 },
+    { dpx::Raw  , dpx::RGBA     , 10, dpx::MethodA, dpx::LE, dpx::Raw_RGBA_10_FilledA_LE },
+    { dpx::Raw  , dpx::RGBA     , 10, dpx::MethodA, dpx::BE, dpx::Raw_RGBA_10_FilledA_BE },
+    { dpx::Raw  , dpx::RGBA     , 12, dpx::Packed , dpx::BE, dpx::Raw_RGBA_12_Packed_BE },
+    { dpx::Raw  , dpx::RGBA     , 12, dpx::MethodA, dpx::BE, dpx::Raw_RGBA_12_FilledA_BE },
+    { dpx::Raw  , dpx::RGBA     , 12, dpx::MethodA, dpx::LE, dpx::Raw_RGBA_12_FilledA_LE },
+    { dpx::Raw  , dpx::RGBA     , 16, dpx::Packed , dpx::BE, dpx::Raw_RGBA_16_BE },
+    { dpx::Raw  , dpx::RGBA     , 16, dpx::Packed , dpx::LE, dpx::Raw_RGBA_16_LE },
+    { dpx::Raw  , dpx::RGBA     , 16, dpx::MethodA, dpx::BE, dpx::Raw_RGBA_16_BE },
+    { dpx::Raw  , dpx::RGBA     , 16, dpx::MethodA, dpx::LE, dpx::Raw_RGBA_16_LE },
 };
 
 //---------------------------------------------------------------------------
@@ -105,7 +76,7 @@ const char* dpx::ErrorMessage()
 dpx::dpx() :
     RAWcooked(NULL),
     IsDetected(false),
-    Style(DPX_Style_Max),
+    Style(Style_Max),
     FrameRate(NULL),
     error_message(NULL)
 {
@@ -223,8 +194,7 @@ bool dpx::Parse()
     Buffer_Offset = 803;
     uint8_t BitDepth = Get_X1();
     uint16_t Packing = Get_X2();
-    if (Get_X2() != 0)
-        return Error("Encoding");
+    uint16_t Encoding = Get_X2();
     uint32_t OffsetToData = Get_X4();
     if (OffsetToData != OffsetToImage)
         return Error("Offset to data");
@@ -264,6 +234,7 @@ bool dpx::Parse()
     {
         dpx_tested& DPX_Tested_Item = DPX_Tested[Tested];
         if (DPX_Tested_Item.Descriptor == Descriptor
+            && DPX_Tested_Item.Encoding == Encoding
             && DPX_Tested_Item.BitDepth == BitDepth
             && DPX_Tested_Item.Packing == Packing
             && DPX_Tested_Item.Endianess == (IsBigEndian ? BE : LE))
@@ -329,28 +300,28 @@ size_t dpx::BitsPerBlock(dpx::style Style)
 {
     switch (Style)
     {
-        case dpx::RGB_8:                // 3x8-bit content
+        case dpx::Raw_RGB_8:                // 3x8-bit content
                                         return 24;
-        case dpx::RGB_10_FilledA_BE:    // 3x10-bit content + 2-bit zero-padding in 32-bit
-        case dpx::RGB_10_FilledA_LE:    // 3x10-bit content + 2-bit zero-padding in 32-bit
-        case dpx::RGBA_8:               // 4x8-bit content
+        case dpx::Raw_RGB_10_FilledA_BE:    // 3x10-bit content + 2-bit zero-padding in 32-bit
+        case dpx::Raw_RGB_10_FilledA_LE:    // 3x10-bit content + 2-bit zero-padding in 32-bit
+        case dpx::Raw_RGBA_8:               // 4x8-bit content
                                         return 32;
-        case dpx::RGB_12_FilledA_BE:    // 3x(12-bit content + 4-bit zero-padding)
-        case dpx::RGB_12_FilledA_LE:    // 3x(12-bit content + 4-bit zero-padding)
-        case dpx::RGB_16_BE:            // 3x16-bit content
-        case dpx::RGB_16_LE:            // 3x16-bit content
+        case dpx::Raw_RGB_12_FilledA_BE:    // 3x(12-bit content + 4-bit zero-padding)
+        case dpx::Raw_RGB_12_FilledA_LE:    // 3x(12-bit content + 4-bit zero-padding)
+        case dpx::Raw_RGB_16_BE:            // 3x16-bit content
+        case dpx::Raw_RGB_16_LE:            // 3x16-bit content
                                         return 48; 
-        case dpx::RGBA_12_FilledA_BE:   // 4x(12-bit content + 4-bit zero-padding)
-        case dpx::RGBA_12_FilledA_LE:   // 4x(12-bit content + 4-bit zero-padding)
-        case dpx::RGBA_16_BE:           // 4x16-bit content
-        case dpx::RGBA_16_LE:           // 4x16-bit content
+        case dpx::Raw_RGBA_12_FilledA_BE:   // 4x(12-bit content + 4-bit zero-padding)
+        case dpx::Raw_RGBA_12_FilledA_LE:   // 4x(12-bit content + 4-bit zero-padding)
+        case dpx::Raw_RGBA_16_BE:           // 4x16-bit content
+        case dpx::Raw_RGBA_16_LE:           // 4x16-bit content
                                         return 64; 
-        case dpx::RGBA_12_Packed_BE:    // 4x12-bit content, multiplied by 2 pixels in a supported block
+        case dpx::Raw_RGBA_12_Packed_BE:    // 4x12-bit content, multiplied by 2 pixels in a supported block
                                         return 96; 
-        case dpx::RGBA_10_FilledA_BE:   // 4x10-bit content, 2-bit padding every 30-bit, multiplied by 3 pixels in a supported block
-        case dpx::RGBA_10_FilledA_LE:   // 4x10-bit content, 2-bit padding every 30-bit, multiplied by 3 pixels in a supported block
+        case dpx::Raw_RGBA_10_FilledA_BE:   // 4x10-bit content, 2-bit padding every 30-bit, multiplied by 3 pixels in a supported block
+        case dpx::Raw_RGBA_10_FilledA_LE:   // 4x10-bit content, 2-bit padding every 30-bit, multiplied by 3 pixels in a supported block
                                         return 128; 
-        case dpx::RGB_12_Packed_BE:     // 3x12-bit content, multiplied by 8 pixels in a supported block
+        case dpx::Raw_RGB_12_Packed_BE:     // 3x12-bit content, multiplied by 8 pixels in a supported block
                                         return 288;
         default:
                                         return 0;
@@ -362,27 +333,215 @@ size_t dpx::PixelsPerBlock(dpx::style Style)
 {
     switch (Style)
     {
-        case dpx::RGB_8:
-        case dpx::RGBA_8:
-        case dpx::RGB_10_FilledA_BE:
-        case dpx::RGB_10_FilledA_LE:
-        case dpx::RGB_12_FilledA_BE:
-        case dpx::RGB_12_FilledA_LE:
-        case dpx::RGB_16_BE:
-        case dpx::RGB_16_LE:
-        case dpx::RGBA_12_FilledA_BE:
-        case dpx::RGBA_12_FilledA_LE:
-        case dpx::RGBA_16_BE:
-        case dpx::RGBA_16_LE:
+        case dpx::Raw_RGB_8:
+        case dpx::Raw_RGBA_8:
+        case dpx::Raw_RGB_10_FilledA_BE:
+        case dpx::Raw_RGB_10_FilledA_LE:
+        case dpx::Raw_RGB_12_FilledA_BE:
+        case dpx::Raw_RGB_12_FilledA_LE:
+        case dpx::Raw_RGB_16_BE:
+        case dpx::Raw_RGB_16_LE:
+        case dpx::Raw_RGBA_12_FilledA_BE:
+        case dpx::Raw_RGBA_12_FilledA_LE:
+        case dpx::Raw_RGBA_16_BE:
+        case dpx::Raw_RGBA_16_LE:
                                         return 1;
-        case dpx::RGBA_12_Packed_BE:    // 2x4x12-bit in 3x32-bit
+        case dpx::Raw_RGBA_12_Packed_BE:    // 2x4x12-bit in 3x32-bit
                                         return 2;
-        case dpx::RGBA_10_FilledA_BE:   // 3x4x10-bit in 3x32-bit
-        case dpx::RGBA_10_FilledA_LE:   // 3x4x10-bit in 3x32-bit
+        case dpx::Raw_RGBA_10_FilledA_BE:   // 3x4x10-bit in 3x32-bit
+        case dpx::Raw_RGBA_10_FilledA_LE:   // 3x4x10-bit in 3x32-bit
                                         return 3;
-        case dpx::RGB_12_Packed_BE:     // 8x3x12-bit in 9x32-bit
+        case dpx::Raw_RGB_12_Packed_BE:     // 8x3x12-bit in 9x32-bit
                                         return 8;
         default:
                                         return 0;
     }
+}
+
+//---------------------------------------------------------------------------
+dpx::descriptor dpx::ColorSpace(dpx::style Style)
+{
+    switch (Style)
+    {
+        case Raw_RGB_8:
+        case Raw_RGB_10_FilledA_BE:
+        case Raw_RGB_10_FilledA_LE:
+        case Raw_RGB_12_FilledA_BE:
+        case Raw_RGB_12_FilledA_LE:
+        case Raw_RGB_12_Packed_BE:
+        case Raw_RGB_16_BE:
+        case Raw_RGB_16_LE:
+                                        return RGB;
+        case Raw_RGBA_8:
+        case Raw_RGBA_10_FilledA_BE:
+        case Raw_RGBA_10_FilledA_LE:
+        case Raw_RGBA_12_FilledA_BE:
+        case Raw_RGBA_12_FilledA_LE:
+        case Raw_RGBA_16_BE:
+        case Raw_RGBA_16_LE:
+        case Raw_RGBA_12_Packed_BE:
+                                        return RGBA;
+        default:
+                                        return (dpx::descriptor)-1;
+    }
+}
+const char* dpx::ColorSpace_String(dpx::style Style)
+{
+    dpx::descriptor Value = dpx::ColorSpace(Style);
+
+    switch (Value)
+    {
+        case RGB:
+                                        return "RGB";
+        case RGBA:
+                                        return "RGBA";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+uint8_t dpx::BitDepth(dpx::style Style)
+{
+    switch (Style)
+    {
+        case Raw_RGB_8:
+        case Raw_RGBA_8:
+                                        return 8;
+        case Raw_RGB_10_FilledA_BE:
+        case Raw_RGB_10_FilledA_LE:
+        case Raw_RGBA_10_FilledA_BE:
+        case Raw_RGBA_10_FilledA_LE:
+                                        return 10;
+        case Raw_RGB_12_FilledA_BE:
+        case Raw_RGB_12_FilledA_LE:
+        case Raw_RGB_12_Packed_BE:
+        case Raw_RGBA_12_FilledA_BE:
+        case Raw_RGBA_12_FilledA_LE:
+        case Raw_RGBA_12_Packed_BE:
+                                        return 12;
+        case Raw_RGB_16_BE:
+        case Raw_RGB_16_LE:
+        case Raw_RGBA_16_BE:
+        case Raw_RGBA_16_LE:
+                                        return 16;
+        default:
+                                        return 0;
+    }
+}
+const char* dpx::BitDepth_String(dpx::style Style)
+{
+    uint8_t Value = dpx::BitDepth(Style);
+
+    switch (Value)
+    {
+        case 8:
+                                        return "8";
+        case 10:
+                                        return "10";
+        case 12:
+                                        return "12";
+        case 16:
+                                        return "16";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+dpx::packing dpx::Packing(dpx::style Style)
+{
+    switch (Style)
+    {
+        case Raw_RGB_10_FilledA_BE:
+        case Raw_RGB_10_FilledA_LE:
+        case Raw_RGBA_10_FilledA_BE:
+        case Raw_RGBA_10_FilledA_LE:
+        case Raw_RGB_12_FilledA_BE:
+        case Raw_RGB_12_FilledA_LE:
+        case Raw_RGBA_12_FilledA_BE:
+        case Raw_RGBA_12_FilledA_LE:
+                                        return MethodA;
+        case Raw_RGB_12_Packed_BE:
+        case Raw_RGBA_12_Packed_BE:
+                                        return Packed;
+        default:
+                                        return (packing)-1;
+    }
+}
+const char* dpx::Packing_String(dpx::style Style)
+{
+    dpx::packing Value = dpx::Packing(Style);
+
+    switch (Value)
+    {
+        case Packed:
+                                        return "Packed";
+        case MethodA:
+                                        return "FilledA";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+dpx::endianess dpx::Endianess(dpx::style Style)
+{
+    switch (Style)
+    {
+        case Raw_RGB_10_FilledA_LE:
+        case Raw_RGB_12_FilledA_LE:
+        case Raw_RGB_16_LE:
+        case Raw_RGBA_10_FilledA_LE:
+        case Raw_RGBA_12_FilledA_LE:
+        case Raw_RGBA_16_LE:
+                                        return LE;
+        case Raw_RGB_10_FilledA_BE:
+        case Raw_RGB_12_Packed_BE:
+        case Raw_RGB_12_FilledA_BE:
+        case Raw_RGB_16_BE:
+        case Raw_RGBA_10_FilledA_BE:
+        case Raw_RGBA_12_Packed_BE:
+        case Raw_RGBA_12_FilledA_BE:
+        case Raw_RGBA_16_BE:
+                                        return BE;
+        default:
+                                        return (dpx::endianess)-1;
+    }
+}
+const char* dpx::Endianess_String(dpx::style Style)
+{
+    dpx::endianess Value = dpx::Endianess(Style);
+
+    switch (Value)
+    {
+        case LE:
+                                        return "LE";
+        case BE:
+                                        return "BE";
+        default:
+                                        return "";
+    }
+}
+//---------------------------------------------------------------------------
+string dpx::Flavor_String(dpx::style Style)
+{
+    string ToReturn("DPX/Raw/");
+    ToReturn += ColorSpace_String(Style);
+    ToReturn += '/';
+    ToReturn += BitDepth_String(Style);
+    ToReturn += "bit";
+    const char* Value = Packing_String(Style);
+    if (Value[0])
+    {
+        ToReturn += '/';
+        ToReturn += Value;
+    }
+    Value = Endianess_String(Style);
+    if (Value[0])
+    {
+        ToReturn += '/';
+        ToReturn += Value;
+    }
+    return ToReturn;
 }

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -33,7 +33,7 @@ public:
 
     // Info
     bool                        IsDetected;
-    uint64_t                    Style;
+    uint8_t                     Style;
     size_t                      slice_x;
     size_t                      slice_y;
     string*                     FrameRate;
@@ -41,30 +41,74 @@ public:
     // Error message
     const char*                 ErrorMessage();
 
-    enum style
+    enum style : uint8_t
     {
-        RGB_8,
-        RGB_10_FilledA_LE,
-        RGB_10_FilledA_BE,
-        RGB_12_Packed_BE,
-        RGB_12_FilledA_BE,
-        RGB_12_FilledA_LE,
-        RGB_16_BE,
-        RGB_16_LE,
-        RGBA_8,
-        RGBA_10_FilledA_LE,
-        RGBA_10_FilledA_BE,
-        RGBA_12_Packed_BE,
-        RGBA_12_FilledA_BE,
-        RGBA_12_FilledA_LE,
-        RGBA_16_BE,
-        RGBA_16_LE,
-        DPX_Style_Max,
+        Raw_RGB_8,
+        Raw_RGB_10_FilledA_LE,
+        Raw_RGB_10_FilledA_BE,
+        Raw_RGB_12_Packed_BE,
+        Raw_RGB_12_FilledA_BE,
+        Raw_RGB_12_FilledA_LE,
+        Raw_RGB_16_BE,
+        Raw_RGB_16_LE,
+        Raw_RGBA_8,
+        Raw_RGBA_10_FilledA_LE,
+        Raw_RGBA_10_FilledA_BE,
+        Raw_RGBA_12_Packed_BE,
+        Raw_RGBA_12_FilledA_BE,
+        Raw_RGBA_12_FilledA_LE,
+        Raw_RGBA_16_BE,
+        Raw_RGBA_16_LE,
+        Style_Max,
+    };
+
+    enum endianess : uint8_t
+    {
+        LE,
+        BE,
+    };
+    enum descriptor : uint8_t
+    {
+        R           =   1,
+        G           =   2,
+        B           =   3,
+        A           =   4,
+        Y           =   6,
+        ColorDiff   =   7,
+        Z           =   8,
+        Composite   =   9,
+        RGB         =  50,
+        RGBA        =  51,
+        ABGR        =  52,
+        CbYCrY      = 100,
+        CbYACrYA    = 101,
+        CbYCr       = 102,
+        CbYCrA      = 103,
+    };
+    enum encoding : uint8_t
+    {
+        Raw,
+        RLE,
+    };
+    enum packing : uint8_t
+    {
+        Packed,
+        MethodA,
+        MethodB,
     };
 
     // Info about formats
     static size_t BitsPerBlock(style Style);
     static size_t PixelsPerBlock(style Style); // Need no overlap every x pixels
+    static descriptor ColorSpace(style Style);
+    static const char* ColorSpace_String(style Style);
+    static uint8_t BitDepth(style Style);
+    static const char* BitDepth_String(style Style);
+    static packing Packing(style Style);
+    static const char* Packing_String(style Style);
+    static endianess Endianess(style Style);
+    static const char* Endianess_String(style Style);
+    static string Flavor_String(style Style);
 
 private:
     size_t                      Buffer_Offset;

--- a/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.cpp
+++ b/Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.cpp
@@ -100,25 +100,25 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
 
         switch (Style_Private)
         {
-            case dpx::RGB_8:
+            case dpx::Raw_RGB_8:
                                         {
                                         FrameBuffer_Temp_8[x*3]   = (uint8_t)r;
                                         FrameBuffer_Temp_8[x*3+1] = (uint8_t)g;
                                         FrameBuffer_Temp_8[x*3+2] = (uint8_t)b;
                                         }
                                         break;
-            case dpx::RGB_10_FilledA_LE:
+            case dpx::Raw_RGB_10_FilledA_LE:
                                         {
                                         FrameBuffer_Temp_32[x] = (r << 22) | (b << 12) | (g << 2); // Exception indicated in specs, g and b are inverted
                                         }
                                         break;
-            case dpx::RGB_10_FilledA_BE:
+            case dpx::Raw_RGB_10_FilledA_BE:
                                         {
                                         uint32_t c = (r << 22) | (b << 12) | (g << 2); // Exception indicated in specs, g and b are inverted
                                         FrameBuffer_Temp_32[x] = ((c & 0xFF000000) >> 24) | ((c & 0x00FF0000) >> 8) | ((c & 0x0000FF00) << 8) | ((c & 0x000000FF) << 24); // Swap bytes
                                         }
                                         break;
-            case dpx::RGB_12_Packed_BE:
+            case dpx::Raw_RGB_12_Packed_BE:
                                         {
                                         uint32_t c; // Exception indicated in specs, g and b are inverted
                                         swap(b, g);
@@ -172,35 +172,35 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                             s = 0;
                                         }
                                         break;
-            case dpx::RGB_12_FilledA_BE:
+            case dpx::Raw_RGB_12_FilledA_BE:
                                         {  // Exception indicated in specs, g and b are inverted
                                         FrameBuffer_Temp_16[x*3]   = ((r & 0xFF0) >> 4) | ((r & 0xF) << 12);  // Swap bytes after shift by 4
                                         FrameBuffer_Temp_16[x*3+1] = ((b & 0xFF0) >> 4) | ((b & 0xF) << 12);  // Swap bytes after shift by 4
                                         FrameBuffer_Temp_16[x*3+2] = ((g & 0xFF0) >> 4) | ((g & 0xF) << 12);  // Swap bytes after shift by 4
                                         }
                                         break;
-            case dpx::RGB_12_FilledA_LE:
+            case dpx::Raw_RGB_12_FilledA_LE:
                                         {  // Exception indicated in specs, g and b are inverted
                                         FrameBuffer_Temp_16[x*3]   = r << 4;
                                         FrameBuffer_Temp_16[x*3+1] = b << 4;
                                         FrameBuffer_Temp_16[x*3+2] = g << 4;
                                         }
                                         break;
-            case dpx::RGB_16_BE:
+            case dpx::Raw_RGB_16_BE:
                                         { 
                                         FrameBuffer_Temp_16[x*3]   = ((r & 0xFF00) >> 8) | ((r & 0xFF) << 8);  // Swap bytes
                                         FrameBuffer_Temp_16[x*3+1] = ((g & 0xFF00) >> 8) | ((g & 0xFF) << 8);  // Swap bytes
                                         FrameBuffer_Temp_16[x*3+2] = ((b & 0xFF00) >> 8) | ((b & 0xFF) << 8);  // Swap bytes
                                         }
                                         break;
-            case dpx::RGB_16_LE:
+            case dpx::Raw_RGB_16_LE:
                                         { 
                                         FrameBuffer_Temp_16[x*3]   = r;
                                         FrameBuffer_Temp_16[x*3+1] = g;
                                         FrameBuffer_Temp_16[x*3+2] = b;
                                         }
                                         break;
-            case dpx::RGBA_8:
+            case dpx::Raw_RGBA_8:
                                         {
                                         pixel_t a = A[x];
                                         FrameBuffer_Temp_8[x*4]   = (uint8_t)r;
@@ -209,7 +209,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                         FrameBuffer_Temp_8[x*4+3] = (uint8_t)a;
                                         }
                                         break;
-            case dpx::RGBA_10_FilledA_BE:
+            case dpx::Raw_RGBA_10_FilledA_BE:
                                         {
                                         pixel_t a = A[x];
                                         uint32_t c;
@@ -238,7 +238,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                             s = 0;
                                         }
                                         break;
-            case dpx::RGBA_10_FilledA_LE:
+            case dpx::Raw_RGBA_10_FilledA_LE:
                                         {
                                         pixel_t a = A[x];
                                         switch (s)
@@ -262,7 +262,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                             s = 0;
                                         }
                                         break;
-            case dpx::RGBA_12_Packed_BE:
+            case dpx::Raw_RGBA_12_Packed_BE:
                                         {
                                         pixel_t a = A[x];
                                         uint32_t c;
@@ -286,7 +286,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                             s = 0;
                                         }
                                         break;
-            case dpx::RGBA_12_FilledA_BE:
+            case dpx::Raw_RGBA_12_FilledA_BE:
                                         {
                                         pixel_t a = A[x];
                                         FrameBuffer_Temp_16[x*4]   = (uint16_t)((r & 0xFF0) >> 4) | ((r & 0xF) << 12);  // Swap bytes after shift by 4
@@ -295,7 +295,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                         FrameBuffer_Temp_16[x*4+3] = (uint16_t)((a & 0xFF0) >> 4) | ((a & 0xF) << 12);  // Swap bytes after shift by 4
                                         }
                                         break;
-            case dpx::RGBA_12_FilledA_LE:
+            case dpx::Raw_RGBA_12_FilledA_LE:
                                         {
                                         pixel_t a = A[x];
                                         FrameBuffer_Temp_16[x*4]   = r << 4;
@@ -304,7 +304,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                         FrameBuffer_Temp_16[x*4+3] = a << 4;
                                         }
                                         break;
-            case dpx::RGBA_16_BE:
+            case dpx::Raw_RGBA_16_BE:
                                         {
                                         pixel_t a = A[x];
                                         FrameBuffer_Temp_16[x*4]   = (uint16_t)((r & 0xFF00) >> 8) | ((r & 0xFF) << 8);  // Swap bytes
@@ -313,7 +313,7 @@ void transform_jpeg2000rct::DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* 
                                         FrameBuffer_Temp_16[x*4+3] = (uint16_t)((a & 0xFF00) >> 8) | ((a & 0xFF) << 8);  // Swap bytes
                                         }
                                         break;
-            case dpx::RGBA_16_LE:
+            case dpx::Raw_RGBA_16_LE:
                                         {
                                         pixel_t a = A[x];
                                         FrameBuffer_Temp_16[x*4]   = r;

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -383,6 +383,7 @@ void matroska_ProgressIndicator_Show(matroska* M)
 
 //---------------------------------------------------------------------------
 matroska::matroska() :
+    Quiet(false),
     IsDetected(false)
 {
     FramesPool = new ThreadPool(1);
@@ -451,7 +452,9 @@ void matroska::Parse()
     Timestampscale = 1000000;
     Cluster_Timestamp = 0;
     Block_Timestamp = 0;
-    thread ProgressIndicator_Thread(matroska_ProgressIndicator_Show, this);
+    thread* ProgressIndicator_Thread;
+    if (!Quiet)
+        ProgressIndicator_Thread=new thread(matroska_ProgressIndicator_Show, this);
 
     Levels[Level].Offset_End = Buffer_Size;
     Levels[Level].SubElements = &matroska::SubElements__;
@@ -481,8 +484,12 @@ void matroska::Parse()
 
     // Progress indicator
     Buffer_Offset = Buffer_Size;
-    ProgressIndicator_IsEnd.notify_one();
-    ProgressIndicator_Thread.join();
+    if (!Quiet)
+    {
+        ProgressIndicator_IsEnd.notify_one();
+        ProgressIndicator_Thread->join();
+        delete ProgressIndicator_Thread;
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -35,6 +35,7 @@ public:
     void                        Shutdown();
 
     string                      OutputDirectoryName;
+    bool                        Quiet;
 
     // Info
     bool                        IsDetected;

--- a/Source/Lib/RIFF/RIFF.cpp
+++ b/Source/Lib/RIFF/RIFF.cpp
@@ -11,51 +11,45 @@
 
 //---------------------------------------------------------------------------
 // Tested cases
-enum endianess
-{
-    BE, // Or Signed for 8-bit
-    LE, // Or Unsigned for 8-bit
-};
-
 struct riff_tested
 {
     uint32_t                    SamplesPerSec;
     uint8_t                     BitDepth;
     uint8_t                     Channels;
-    endianess                   Endianess;
+    riff::endianess             Endianess;
     riff::style                 Style;
 };
 
 const size_t RIFF_Tested_Size = 27;
 struct riff_tested RIFF_Tested[RIFF_Tested_Size] =
 {
-    { 44100,  8, 1, LE, riff::PCM_44100_8_1_U },
-    { 44100,  8, 2, LE, riff::PCM_44100_8_2_U },
-    { 44100,  8, 6, LE, riff::PCM_44100_8_6_U },
-    { 44100, 16, 1, LE, riff::PCM_44100_16_1_LE },
-    { 44100, 16, 2, LE, riff::PCM_44100_16_2_LE },
-    { 44100, 16, 6, LE, riff::PCM_44100_16_6_LE },
-    { 44100, 24, 1, LE, riff::PCM_44100_24_1_LE },
-    { 44100, 24, 2, LE, riff::PCM_44100_24_2_LE },
-    { 44100, 24, 6, LE, riff::PCM_44100_24_6_LE },
-    { 48000,  8, 1, LE, riff::PCM_44100_8_1_U },
-    { 48000,  8, 2, LE, riff::PCM_44100_8_2_U },
-    { 48000,  8, 6, LE, riff::PCM_44100_8_6_U },
-    { 48000, 16, 1, LE, riff::PCM_48000_16_1_LE },
-    { 48000, 16, 2, LE, riff::PCM_48000_16_2_LE },
-    { 48000, 16, 6, LE, riff::PCM_48000_16_6_LE },
-    { 48000, 24, 1, LE, riff::PCM_48000_24_1_LE },
-    { 48000, 24, 2, LE, riff::PCM_48000_24_2_LE },
-    { 48000, 24, 6, LE, riff::PCM_48000_24_6_LE },
-    { 96000,  8, 1, LE, riff::PCM_44100_8_1_U },
-    { 96000,  8, 2, LE, riff::PCM_44100_8_2_U },
-    { 96000,  8, 6, LE, riff::PCM_44100_8_6_U },
-    { 96000, 16, 1, LE, riff::PCM_96000_16_1_LE },
-    { 96000, 16, 2, LE, riff::PCM_96000_16_2_LE },
-    { 96000, 16, 6, LE, riff::PCM_96000_16_6_LE },
-    { 96000, 24, 1, LE, riff::PCM_96000_24_1_LE },
-    { 96000, 24, 2, LE, riff::PCM_96000_24_2_LE },
-    { 96000, 24, 6, LE, riff::PCM_96000_24_6_LE },
+    { 44100,  8, 1, riff::LE, riff::PCM_44100_8_1_U },
+    { 44100,  8, 2, riff::LE, riff::PCM_44100_8_2_U },
+    { 44100,  8, 6, riff::LE, riff::PCM_44100_8_6_U },
+    { 44100, 16, 1, riff::LE, riff::PCM_44100_16_1_LE },
+    { 44100, 16, 2, riff::LE, riff::PCM_44100_16_2_LE },
+    { 44100, 16, 6, riff::LE, riff::PCM_44100_16_6_LE },
+    { 44100, 24, 1, riff::LE, riff::PCM_44100_24_1_LE },
+    { 44100, 24, 2, riff::LE, riff::PCM_44100_24_2_LE },
+    { 44100, 24, 6, riff::LE, riff::PCM_44100_24_6_LE },
+    { 48000,  8, 1, riff::LE, riff::PCM_44100_8_1_U },
+    { 48000,  8, 2, riff::LE, riff::PCM_44100_8_2_U },
+    { 48000,  8, 6, riff::LE, riff::PCM_44100_8_6_U },
+    { 48000, 16, 1, riff::LE, riff::PCM_48000_16_1_LE },
+    { 48000, 16, 2, riff::LE, riff::PCM_48000_16_2_LE },
+    { 48000, 16, 6, riff::LE, riff::PCM_48000_16_6_LE },
+    { 48000, 24, 1, riff::LE, riff::PCM_48000_24_1_LE },
+    { 48000, 24, 2, riff::LE, riff::PCM_48000_24_2_LE },
+    { 48000, 24, 6, riff::LE, riff::PCM_48000_24_6_LE },
+    { 96000,  8, 1, riff::LE, riff::PCM_44100_8_1_U },
+    { 96000,  8, 2, riff::LE, riff::PCM_44100_8_2_U },
+    { 96000,  8, 6, riff::LE, riff::PCM_44100_8_6_U },
+    { 96000, 16, 1, riff::LE, riff::PCM_96000_16_1_LE },
+    { 96000, 16, 2, riff::LE, riff::PCM_96000_16_2_LE },
+    { 96000, 16, 6, riff::LE, riff::PCM_96000_16_6_LE },
+    { 96000, 24, 1, riff::LE, riff::PCM_96000_24_1_LE },
+    { 96000, 24, 2, riff::LE, riff::PCM_96000_24_2_LE },
+    { 96000, 24, 6, riff::LE, riff::PCM_96000_24_6_LE },
 };
 
 //---------------------------------------------------------------------------
@@ -113,7 +107,7 @@ const char* riff::ErrorMessage()
 riff::riff() :
     RAWcooked(NULL),
     IsDetected(false),
-    Style(PCM_Style_Max),
+    Style(Style_Max),
     error_message(NULL)
 {
 }
@@ -240,7 +234,7 @@ uint8_t riff::BitDepth()
 }
 
 //---------------------------------------------------------------------------
-uint8_t riff::Endianess()
+riff::endianess riff::Endianess()
 {
     return RIFF_Tested[Style].Endianess;
 }
@@ -392,5 +386,213 @@ void riff::WAVE_fmt_()
         return;
     }
     Style = RIFF_Tested[Tested].Style;
+}
+
+//---------------------------------------------------------------------------
+uint32_t riff::SamplesPerSec(riff::style Style)
+{
+    switch (Style)
+    {
+        case PCM_44100_8_1_U:
+        case PCM_44100_8_2_U:
+        case PCM_44100_8_6_U:
+        case PCM_44100_16_1_LE:
+        case PCM_44100_16_2_LE:
+        case PCM_44100_16_6_LE:
+        case PCM_44100_24_1_LE:
+        case PCM_44100_24_2_LE:
+        case PCM_44100_24_6_LE:
+                                        return 44100;
+        case PCM_48000_8_1_U:
+        case PCM_48000_8_2_U:
+        case PCM_48000_8_6_U:
+        case PCM_48000_16_1_LE:
+        case PCM_48000_16_2_LE:
+        case PCM_48000_16_6_LE:
+        case PCM_48000_24_1_LE:
+        case PCM_48000_24_2_LE:
+        case PCM_48000_24_6_LE:
+                                        return 48000;
+        case PCM_96000_8_1_U:
+        case PCM_96000_8_2_U:
+        case PCM_96000_8_6_U:
+        case PCM_96000_16_1_LE:
+        case PCM_96000_16_2_LE:
+        case PCM_96000_16_6_LE:
+        case PCM_96000_24_1_LE:
+        case PCM_96000_24_2_LE:
+        case PCM_96000_24_6_LE:
+                                        return 96000;
+        default:
+                                        return 0;
+    }
+}
+const char* riff::SamplesPerSec_String(riff::style Style)
+{
+    uint32_t Value = riff::SamplesPerSec(Style);
+
+    switch (Value)
+    {
+        case 44100:
+                                        return "44";
+        case 48000:
+                                        return "48";
+        case 96000:
+                                        return "96";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+uint8_t riff::BitDepth(riff::style Style)
+{
+    switch (Style)
+    {
+        case PCM_44100_8_1_U:
+        case PCM_44100_8_2_U:
+        case PCM_44100_8_6_U:
+        case PCM_48000_8_1_U:
+        case PCM_48000_8_2_U:
+        case PCM_48000_8_6_U:
+        case PCM_96000_8_1_U:
+        case PCM_96000_8_2_U:
+        case PCM_96000_8_6_U:
+                                        return 8;
+        case PCM_44100_16_1_LE:
+        case PCM_44100_16_2_LE:
+        case PCM_44100_16_6_LE:
+        case PCM_48000_16_1_LE:
+        case PCM_48000_16_2_LE:
+        case PCM_48000_16_6_LE:
+        case PCM_96000_16_1_LE:
+        case PCM_96000_16_2_LE:
+        case PCM_96000_16_6_LE:
+                                        return 16;
+        case PCM_44100_24_1_LE:
+        case PCM_44100_24_2_LE:
+        case PCM_44100_24_6_LE:
+        case PCM_48000_24_1_LE:
+        case PCM_48000_24_2_LE:
+        case PCM_48000_24_6_LE:
+        case PCM_96000_24_1_LE:
+        case PCM_96000_24_2_LE:
+        case PCM_96000_24_6_LE:
+                                        return 24;
+        default:
+                                        return 0;
+    }
+}
+const char* riff::BitDepth_String(riff::style Style)
+{
+    uint8_t Value = riff::BitDepth(Style);
+
+    switch (Value)
+    {
+        case 8:
+                                        return "8";
+        case 16:
+                                        return "16";
+        case 24:
+                                        return "24";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+uint8_t riff::Channels(riff::style Style)
+{
+    switch (Style)
+    {
+        case PCM_44100_8_1_U:
+        case PCM_48000_8_1_U:
+        case PCM_96000_8_1_U:
+        case PCM_44100_16_1_LE:
+        case PCM_48000_16_1_LE:
+        case PCM_96000_16_1_LE:
+        case PCM_48000_24_1_LE:
+        case PCM_44100_24_1_LE:
+        case PCM_96000_24_1_LE:
+                                        return 1;
+        case PCM_44100_8_2_U:
+        case PCM_48000_8_2_U:
+        case PCM_96000_8_2_U:
+        case PCM_44100_16_2_LE:
+        case PCM_48000_16_2_LE:
+        case PCM_96000_16_2_LE:
+        case PCM_44100_24_2_LE:
+        case PCM_48000_24_2_LE:
+        case PCM_96000_24_2_LE:
+                                        return 2;
+        case PCM_44100_8_6_U:
+        case PCM_48000_8_6_U:
+        case PCM_96000_8_6_U:
+        case PCM_44100_16_6_LE:
+        case PCM_48000_16_6_LE:
+        case PCM_96000_16_6_LE:
+        case PCM_44100_24_6_LE:
+        case PCM_48000_24_6_LE:
+        case PCM_96000_24_6_LE:
+                                        return 6;
+        default:
+                                        return 0;
+    }
+}
+const char* riff::Channels_String(riff::style Style)
+{
+    uint8_t Value = riff::Channels(Style);
+
+    switch (Value)
+    {
+        case 1:
+                                        return "1";
+        case 2:
+                                        return "2";
+        case 6:
+                                        return "6";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+riff::endianess riff::Endianess(riff::style Style)
+{
+    return LE; //For the moment all is LE or Unsigned
+}
+const char* riff::Endianess_String(riff::style Style)
+{
+    riff::endianess Value = riff::Endianess(Style);
+    uint8_t BitDepth = riff::BitDepth(Style);
+
+    switch (Value)
+    {
+        case LE:
+                                        return BitDepth==8?"U":"LE";
+        case BE:
+                                        return BitDepth==8?"S":"BE";
+        default:
+                                        return "";
+    }
+}
+
+//---------------------------------------------------------------------------
+string riff::Flavor_String(riff::style Style)
+{
+    string ToReturn("WAV/PCM/");
+    ToReturn += SamplesPerSec_String(Style);
+    ToReturn += "kHz/";
+    ToReturn += BitDepth_String(Style);
+    ToReturn += "bit/";
+    ToReturn += Channels_String(Style);
+    ToReturn += "ch";
+    const char* Value = Endianess_String(Style);
+    if (Value[0])
+    {
+        ToReturn += '/';
+        ToReturn += Value;
+    }
+    return ToReturn;
 }
 

--- a/Source/Lib/RIFF/RIFF.h
+++ b/Source/Lib/RIFF/RIFF.h
@@ -33,7 +33,7 @@ public:
 
     // Info
     bool                        IsDetected;
-    uint64_t                    Style;
+    uint8_t                     Style;
 
     // Error message
     const char*                 ErrorMessage();
@@ -67,12 +67,26 @@ public:
         PCM_96000_24_1_LE,
         PCM_96000_24_2_LE,
         PCM_96000_24_6_LE,
-        PCM_Style_Max,
+        Style_Max,
+    };
+    enum endianess
+    {
+        BE, // Or Signed for 8-bit
+        LE, // Or Unsigned for 8-bit
     };
 
     // Info about formats
     uint8_t BitDepth();
-    uint8_t Endianess();
+    endianess Endianess();
+    static uint32_t SamplesPerSec(style Style);
+    static const char* SamplesPerSec_String(style Style);
+    static uint8_t BitDepth(style Style);
+    static const char* BitDepth_String(style Style);
+    static uint8_t Channels(style Style);
+    static const char* Channels_String(style Style);
+    static endianess Endianess(style Style);
+    static const char* Endianess_String(style Style);
+    static string Flavor_String(style Style);
 
 private:
     size_t                      Buffer_Offset;


### PR DESCRIPTION
Example of information for [this example](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/tree/master/Features/AV_Package/818_DCDM_P3_IA_FIC_000918):

~~~
Track 1:
  818_OV\818_OV_%07d.dpx (0086945 --> 0086956)
  DPX/Raw/RGB/10bit/FilledA/BE
Track 2:
  818_OV_FR_ST\818_OV_FR_ST_%07d.dpx (0086945 --> 0086956)
  DPX/Raw/RGB/10bit/FilledA/BE
Track 3:
  818_TextlessBGD\818_TextlessBGD_%07d.dpx (0086160 --> 0086165)
  DPX/Raw/RGB/10bit/FilledA/BE
Track 4:
  audio\818_DCP_5point1_20170221.500ms.wav
  WAV/PCM/48kHz/24bit/6ch/LE
Track 5:
  audio\818_Stereo_LtRt_20170329.500ms.wav
  WAV/PCM/48kHz/24bit/2ch/LE
Attachments:
  audio\md5sum.md5
  md5deep.md5
~~~