### PR TITLE
Support of DPX with non zero padding bits

### DIFF
--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -60,7 +60,7 @@ man1_MANS = ../../../Source/CLI/rawcooked.1
 
 AM_TESTS_FD_REDIRECT = 9>&2
 
-TESTS = test/test1.sh test/test2.sh test/test3.sh test/notfound.sh test/version.sh
+TESTS = test/test1.sh test/test1b.sh test/test2.sh test/test3.sh test/notfound.sh test/version.sh
 
 TESTING_DIR = test/TestingFiles
 

--- a/Project/GNU/CLI/test/test1b.sh
+++ b/Project/GNU/CLI/test/test1b.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# same as test1 except ' --check full -slices 4' option
+
+PATH="${PWD}:$PATH"
+script_path="${PWD}/test"
+files_path="${script_path}/TestingFiles"
+
+rcode=0
+
+if type -p md5sum ; then
+    md5cmd="md5sum"
+elif type -p md5 ; then
+    md5cmd="md5 -r"
+else
+    exit 1
+fi >/dev/null 2>&1
+
+fd=1
+if command exec >&9 ; then
+    fd=9
+fi >/dev/null 2>&1
+
+valgrind=""
+#if command -v valgrind ; then
+#    valgrind="valgrind --quiet --log-file=valgrind.log"
+#fi >/dev/null 2>&1
+
+clean() {
+    rm -fr "${file}.mkv.RAWcooked"
+    rm -f "${file}.rawcooked_reversibility_data"
+    rm -f "${file}.mkv"
+}
+
+while read line ; do
+    file="$(basename "$(echo "${line}" | cut -d' ' -f1)")"
+    path="$(dirname "$(echo "${line}" | cut -d' ' -f1)")"
+    want="$(echo "${line}" | cut -d' ' -f2)"
+    test=$(basename "${path}")
+    if [ ! -e "${files_path}/${path}/${file}" ] ; then
+        echo "NOK: ${test}/${file}, file not found" >&${fd}
+        rcode=1
+        continue
+    fi
+
+    pushd "${files_path}/${path}" >/dev/null 2>&1
+        cmdline=$(${valgrind} rawcooked --file --check full -slices 4 -d "${file}" 2>stderr)
+        result=$?
+        stderr="$(<stderr)"
+        rm -f stderr
+
+        # check valgrind
+        if [ -n "${valgrind}" ] && [ -s "valgrind.log" ] ; then
+            cat valgrind.log >&${fd}
+            rcode=1
+        fi
+
+        # check expected result
+        if [ "${want}" == "fail" ] && [ "${result}" -ne "0" ] ; then
+            if [ -n "${stderr}" ] ; then
+                echo "OK: ${test}/${file}, file rejected at input" >&${fd}
+            else
+                echo "NOK: ${test}/${file}, file rejected at input without message" >&${fd}
+                rcode=1
+            fi
+            continue
+        elif [ "${want}" == "fail" ] || [ "${result}" -ne "0" ] ; then
+            echo "NOK: ${test}/${file}, file rejected at input" >&${fd}
+            rcode=1
+            continue
+        fi
+
+        # check result file generation
+        cmdline=$(echo -e "${cmdline}" | grep ffmpeg) 2>/dev/null
+        if [ -n "${cmdline}" ] ; then
+            eval "${cmdline} </dev/null >/dev/null 2>&1"
+        fi
+
+        if [ ! -e "${file}.mkv" ] ; then
+            echo "NOK: ${test}/${file}, mkv not generated" >&${fd}
+            rcode=1
+            continue
+        fi
+
+        # check framemd5
+        media=$(ffmpeg -hide_banner -i "${file}" 2>&1 </dev/null | tr -d ' ' | grep -m1 '^Stream#.\+:.\+' | cut -d ':' -f 3)
+        if [ "${media}" == "Video" ] ; then
+            pixfmt=$(ffmpeg -hide_banner -i "${file}" -f framemd5 "${file}.framemd5" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Video:dpx,' | cut -d, -f2)
+            ffmpeg -i "${file}.mkv" -pix_fmt ${pixfmt} -f framemd5 "${file}.mkv.framemd5" </dev/null
+        elif [ "${media}" == "Audio" ] ; then
+            pcmfmt=$(ffmpeg -hide_banner -i "${file}" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Audio:' | grep -o 'pcm_[[:alnum:]]\+')
+            ffmpeg -i "${file}" -c:a ${pcmfmt} -f framemd5 "${file}.framemd5" </dev/null
+            ffmpeg -i "${file}.mkv" -c:a ${pcmfmt} -f framemd5 "${file}.mkv.framemd5" </dev/null
+        else
+            echo "NOK: ${test}/${file}, stream format not recognized" >&${fd}
+            clean
+            rcode=1
+            continue
+        fi
+
+        framemd5_a="$(grep -m1 -o '[0-9a-f]\{32\}' "${file}.framemd5")"
+        framemd5_b="$(grep -m1 -o '[0-9a-f]\{32\}' "${file}.mkv.framemd5")"
+        rm -f "${file}.framemd5" "${file}.mkv.framemd5"
+
+        if [ -z "${framemd5_a}" ] || [ -z "${framemd5_b}" ] || [ "${framemd5_a}" != "${framemd5_b}" ] ; then
+            echo "NOK: ${test}/${file}, framemd5 mismatch" >&${fd}
+            clean
+            rcode=1
+            continue
+        fi
+
+        ${valgrind} rawcooked "${file}.mkv" >/dev/null 2>&1
+        result=$?
+
+        # check valgrind
+        if  [ -n "${valgrind}" ] && [ -s "valgrind.log" ] ; then
+            cat valgrind.log >&${fd}
+            rcode=1
+        fi
+
+        md5_a="$(${md5cmd} "${file}" | cut -d' ' -f1)" 2>/dev/null
+        md5_b="$(${md5cmd} "${file}.mkv.RAWcooked/${file}" | cut -d' ' -f1)" 2>/dev/null
+        # check result file
+        if [ -n "${md5_a}" ] && [ -n "${md5_b}" ] && [ "${md5_a}" == "${md5_b}" ] ; then
+            echo "OK: ${test}/${file}, checksums match" >&${fd}
+        else
+            echo "NOK: ${path}/${file}, checksums mismatch" >&${fd}
+            rcode=1
+        fi
+        clean
+    popd >/dev/null 2>&1
+done < "${script_path}/test1b.txt"
+
+exit ${rcode}
+

--- a/Project/GNU/CLI/test/test1b.txt
+++ b/Project/GNU/CLI/test/test1b.txt
@@ -1,0 +1,8 @@
+Formats/DPX/Features/PaddingBitsNotZero/RGB_10_FilledA_BE/10bit.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGB_10_FilledA_LE/image090003.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGB_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_noalpha.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGB_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_noalpha.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGBA_10_FilledA_BE/10bit_a.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGBA_10_FilledA_LE/checkerboard_1080p_nuke_littleendian_10bit_alpha.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGBA_12_FilledA_BE/checkerboard_1080p_nuke_bigendian_12bit_alpha.dpx pass
+Formats/DPX/Features/PaddingBitsNotZero/RGBA_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit_alpha.dpx pass

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -55,6 +55,23 @@ int global::SetAcceptFiles()
 }
 
 //---------------------------------------------------------------------------
+int global::SetFullCheck(const char* Value)
+{
+    if (strcmp(Value, "0") == 0 || strcmp(Value, "partial") == 0)
+    {
+        FullCheck = false;
+        return 0;
+    }
+    if (strcmp(Value, "1") == 0 || strcmp(Value, "full") == 0)
+    {
+        FullCheck = true;
+        return 0;
+    }
+    cerr << "Invalid --check value." << endl;
+    return 1;
+}
+
+//---------------------------------------------------------------------------
 int Error_NotTested(const char* Option1, const char* Option2 = NULL)
 {
     cerr << "Error: option " << Option1;
@@ -218,6 +235,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
     AttachmentMaxSize = (size_t)-1;
     DisplayCommand = false;
     AcceptFiles = false;
+    FullCheck = false;
     Quiet = false;
     ProgressIndicator_Thread = NULL;
 
@@ -248,6 +266,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
         else if ((strcmp(argv[i], "--bin-name") == 0 || strcmp(argv[i], "-b") == 0) && i + 1 < argc)
         {
             int Value = SetBinName(argv[++i]);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--check") == 0 && i + 1 < argc)
+        {
+            int Value = SetFullCheck(argv[++i]);
             if (Value)
                 return Value;
         }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -31,6 +31,7 @@ public:
     string                      BinName;
     bool                        DisplayCommand;
     bool                        AcceptFiles;
+    bool                        FullCheck;
     bool                        HasAtLeastOneDir;
     bool                        HasAtLeastOneFile;
     bool                        Quiet;
@@ -57,6 +58,7 @@ private:
     int SetBinName(const char* FileName);
     int SetDisplayCommand();
     int SetAcceptFiles();
+    int SetFullCheck(const char* Value);
 
     // Progress indicator
     condition_variable          ProgressIndicator_IsEnd;

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -72,6 +72,14 @@ ReturnValue Help(const char* Name)
     cout << "              Set maximum size of attachment to value (in bytes)." << endl;
     cout << "              Default value is 1048576." << endl;
     cout << endl;
+    cout << "       --check value" << endl;
+    cout << "              Do or don't do costly (in terms of analysis duration or bytes read) checks." << endl;
+    cout << "              'partial' (or '0') is quicker but may lead to partial reversibility" << endl;
+    cout <<"               with non conform files." << endl;
+    cout << "              'full' (or '1') is slower but  guaranties reversability with e.g." << endl;
+    cout << "              DPX files with non zero padding bits." << endl;
+    cout << "              Default value is 'partial'." << endl;
+    cout << endl;
     cout << "       --display-command | -d" << endl;
     cout << "              When an external encoder/decoder is used, display the command to" << endl;
     cout << "              launch instead of launching it." << endl;

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -60,7 +60,7 @@ bool parse_info::ParseFile_Input(input_base& SingleFile)
     SingleFile.Buffer_Size = FileMap.Buffer_Size;
 
     // Parse
-    SingleFile.Parse();
+    SingleFile.Parse(false, Global.FullCheck);
     Global.ProgressIndicator_Increment();
     if (SingleFile.ErrorMessage())
     {

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -39,6 +39,15 @@ Set maximum size of attachment to \fIvalue\fR (in bytes).
 .br
 Default value is \fI1048576\fR.
 .TP
+.B \-\-check \fIvalue\fR
+Do or don't do costly (in terms of analysis duration or bytes read) checks.
+.br
+\fIpartial\fR (or \fI0\fR) is quicker but may lead to partial reversibility with non conform files.
+.br
+\fIfull\fR (or \fI1\fR) is slower but  guaranties reversability with e.g. DPX files with non zero padding bits.
+.br
+Default value is 'partial'.
+.TP
 .B \-\-display\-command \fR|\fB \-d
 When an external encoder/decoder is used, display the command to launch instead of launching it.
 .TP

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -21,7 +21,7 @@ class dpx : public input_base_uncompressed
 public:
     dpx();
 
-    bool                        Parse(bool AcceptTruncated = false);
+    bool                        Parse(bool AcceptTruncated = false, bool FullCheck = false);
     string                      Flavor_String();
 
     frame                       Frame;

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -26,7 +26,7 @@ public:
     // Direct access to file map data
     unsigned char*              Buffer;
     size_t                      Buffer_Size;
-    virtual bool                Parse(bool AcceptTruncated = false) = 0;
+    virtual bool                Parse(bool AcceptTruncated = false, bool FullCheck = false) = 0;
 
     // Error message
     const char*                 ErrorMessage();

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -29,7 +29,7 @@ public:
     matroska();
     ~matroska();
 
-    bool                        Parse(bool AcceptTruncated = false);
+    bool                        Parse(bool AcceptTruncated = false, bool FullCheck = false);
     void                        Shutdown();
 
     string                      OutputDirectoryName;
@@ -71,10 +71,12 @@ private:
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_AfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_BeforeData);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_InData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_FileName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionAfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionBeforeData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionFileName);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedBlock_MaskAdditionInData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedSegment_LibraryVersion);
@@ -85,9 +87,11 @@ private:
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_FileName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_LibraryName);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_LibraryVersion);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_InData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_MaskBaseAfterData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_MaskBaseBeforeData);
     MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_MaskBaseFileName);
+    MATROSKA_ELEMENT(Segment_Attachments_AttachedFile_FileData_RawCookedTrack_MaskBaseInData);
     MATROSKA_ELEMENT(Segment_Cluster);
     MATROSKA_ELEMENT(Segment_Cluster_SimpleBlock);
     MATROSKA_ELEMENT(Segment_Cluster_Timestamp);
@@ -116,15 +120,19 @@ private:
         uint8_t*                Mask_FileName;
         uint8_t*                Mask_Before;
         uint8_t*                Mask_After;
+        uint8_t*                Mask_In;
         uint8_t**               DPX_FileName;
         uint8_t**               DPX_Before;
         uint8_t**               DPX_After;
+        uint8_t**               DPX_In;
         size_t                  Mask_FileName_Size;
         size_t                  Mask_Before_Size;
         size_t                  Mask_After_Size;
+        size_t                  Mask_In_Size;
         size_t*                 DPX_FileName_Size;
         size_t*                 DPX_Before_Size;
         size_t*                 DPX_After_Size;
+        size_t*                 DPX_In_Size;
         size_t                  DPX_Buffer_Pos;
         size_t                  DPX_Buffer_Count;
         raw_frame*              R_A;
@@ -138,15 +146,19 @@ private:
             Mask_FileName(NULL),
             Mask_Before(NULL),
             Mask_After(NULL),
+            Mask_In(NULL),
             DPX_FileName(NULL),
             DPX_Before(NULL),
             DPX_After(NULL),
+            DPX_In(NULL),
             Mask_FileName_Size(0),
             Mask_Before_Size(0),
             Mask_After_Size(0),
+            Mask_In_Size(0),
             DPX_FileName_Size(0),
             DPX_Before_Size(0),
             DPX_After_Size(0),
+            DPX_In_Size(0),
             DPX_Buffer_Pos(0),
             DPX_Buffer_Count(0),
             R_A(NULL),

--- a/Source/Lib/RAWcooked/RAWcooked.h
+++ b/Source/Lib/RAWcooked/RAWcooked.h
@@ -30,6 +30,9 @@ public:
     uint8_t*                    After;
     uint64_t                    After_Size;
 
+    uint8_t*                    In;
+    uint64_t                    In_Size;
+
     void                        Parse();
     void                        ResetTrack();
     void                        Close();

--- a/Source/Lib/RIFF/RIFF.cpp
+++ b/Source/Lib/RIFF/RIFF.cpp
@@ -100,7 +100,7 @@ riff::riff() :
 }
 
 //---------------------------------------------------------------------------
-bool riff::Parse(bool AcceptTruncated)
+bool riff::Parse(bool AcceptTruncated, bool FullCheck)
 {
     if (Buffer_Size < 12)
         return false;

--- a/Source/Lib/RIFF/RIFF.h
+++ b/Source/Lib/RIFF/RIFF.h
@@ -21,7 +21,7 @@ class riff : public input_base_uncompressed
 public:
     riff();
 
-    bool                        Parse(bool AcceptTruncated = false);
+    bool                        Parse(bool AcceptTruncated = false, bool FullCheck = false);
     string                      Flavor_String();
 
     enum flavor

--- a/Source/Lib/RawFrame/RawFrame.h
+++ b/Source/Lib/RawFrame/RawFrame.h
@@ -24,6 +24,8 @@ public:
     size_t                      Pre_Size;
     uint8_t*                    Post;
     size_t                      Post_Size;
+    uint8_t*                    In;
+    size_t                      In_Size;
     uint8_t*                    Buffer;
     size_t                      Buffer_Size;
     bool                        Buffer_IsOwned;
@@ -82,6 +84,7 @@ public:
         Flavor_Private(0),
         Pre(NULL),
         Post(NULL),
+        In(NULL),
         Buffer(NULL)
     {
     }


### PR DESCRIPTION
padding bit values are stored in RAWcooked reversibility file.

`--full-check` must be set.