### PR TITLE
Add license management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - >
        if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
-         cd Project/GNU/CLI/ &&
+         pushd Project/GNU/CLI/ &&
          # git clone --depth=1 https://github.com/FFmpeg/FFmpeg.git &&
          curl -O https://mediaarea.net/temp/FFmpeg-20180801.tar.bz2 &&
          tar xjf FFmpeg-20180801.tar.bz2 &&
@@ -26,11 +26,19 @@ before_script:
          make &&
          mv ffmpeg .. &&
          popd;
+         popd;
+         if [[ -n "$PATCH" ]] ; then
+             echo "$PATCH" | base64 -d | git apply -v;
+         fi;
        fi
   - >
        if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
-         cd Project/GNU/CLI/ &&
+         pushd Project/GNU/CLI/ &&
          curl -O "https://evermeet.cx/ffmpeg/$(curl https://evermeet.cx/ffmpeg/ 2>/dev/null | grep -oe 'ffmpeg-[0-9a-z-]\+.7z')" 2>/dev/null &&
          7za e *.7z ;
+         popd;
+         if [[ -n "$PATCH" ]] ; then
+             echo "$PATCH" | base64 -D | git apply -v;
+         fi;
        fi
-script: sh autogen.sh && ./configure && make && make clone_testing_files && make check
+script: cd Project/GNU/CLI/ && sh autogen.sh && ./configure && make && make clone_testing_files && make check

--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -18,6 +18,7 @@ rawcooked_SOURCES = \
     ../../../Source/Lib/FFV1/FFV1_Slice.cpp \
     ../../../Source/Lib/FFV1/Transform/FFV1_Transform_JPEG2000RCT.cpp \
     ../../../Source/Lib/Input_Base.cpp \
+    ../../../Source/Lib/License.cpp \
     ../../../Source/Lib/Matroska/Matroska_Common.cpp \
     ../../../Source/Lib/RAWcooked/RAWcooked.cpp \
     ../../../Source/Lib/RawFrame/RawFrame.cpp \

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
@@ -34,6 +34,8 @@
     <ClInclude Include="..\..\..\Source\Lib\FileIO.h" />
     <ClInclude Include="..\..\..\Source\Lib\FrameHash\FrameHash_MD5.h" />
     <ClInclude Include="..\..\..\Source\Lib\Input_Base.h" />
+    <ClInclude Include="..\..\..\Source\Lib\License.h" />
+    <ClInclude Include="..\..\..\Source\Lib\License_Internal.h" />
     <ClInclude Include="..\..\..\Source\Lib\Matroska\Matroska_Common.h" />
     <ClInclude Include="..\..\..\Source\Lib\RAWcooked\RAWcooked.h" />
     <ClInclude Include="..\..\..\Source\Lib\RawFrame\RawFrame.h" />
@@ -92,6 +94,7 @@
     <ClCompile Include="..\..\..\Source\Lib\FFV1\Transform\FFV1_Transform_JPEG2000RCT.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FileIO.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Input_Base.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\License.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Matroska\Matroska_Common.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\RAWcooked\RAWcooked.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\RawFrame\RawFrame.cpp" />

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
@@ -267,6 +267,12 @@
     <ClInclude Include="..\..\..\Source\Lib\Input_Base.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\License.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\License_Internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\CRC32\ZenCRC32.cpp">
@@ -387,6 +393,9 @@
       <Filter>ThirdParty\flac</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\Input_Base.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\License.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -11,6 +11,7 @@
 
 //---------------------------------------------------------------------------
 #include "CLI/Config.h"
+#include "Lib/License.h"
 #include <map>
 #include <vector>
 #include <string>
@@ -29,6 +30,10 @@ public:
     string                      rawcooked_reversibility_data_FileName;
     string                      OutputFileName;
     string                      BinName;
+    string                      LicenseKey;
+    bool                        IgnoreLicenseKey;
+    bool                        ShowLicenseKey;
+    bool                        StoreLicenseKey;
     bool                        DisplayCommand;
     bool                        AcceptFiles;
     bool                        FullCheck;
@@ -39,6 +44,7 @@ public:
     // Intermediate info
     size_t                      Path_Pos_Global;
     vector<string>              Inputs;
+    license                     License;
 
     // Options
     int ManageCommandLine(const char* argv[], int argc);
@@ -56,6 +62,7 @@ private:
     int SetOption(const char* argv[], int& i, int argc);
     int SetOutputFileName(const char* FileName);
     int SetBinName(const char* FileName);
+    int SetLicenseKey(const char* Key, bool Add);
     int SetDisplayCommand();
     int SetAcceptFiles();
     int SetFullCheck(const char* Value);

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -43,12 +43,14 @@ struct parse_info
     string Slices;
     string FrameRate;
     bool   IsDetected;
+    bool   Problem;
 
     bool ParseFile_Input(input_base& Input);
     bool ParseFile_Input(input_base_uncompressed& SingleFile, input& Input, size_t Files_Pos);
 
     parse_info():
-        IsDetected(false)
+        IsDetected(false),
+        Problem(false)
     {}
 };
 
@@ -114,6 +116,10 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
 
     }
 
+    // License
+    if (!Problem)
+        Problem = !Global.License.IsSupported(SingleFile.ParserCode, SingleFile.Flavor);
+
     return false;
 }
 
@@ -168,6 +174,7 @@ int ParseFile_Uncompressed(parse_info& ParseInfo, size_t Files_Pos)
             Stream.FileName_EndNumber = ParseInfo.FileName_EndNumber;
         }
         Stream.Flavor = ParseInfo.Flavor;
+        Stream.Problem = ParseInfo.Problem;
 
         Stream.Slices = ParseInfo.Slices;
         if (!ParseInfo.FrameRate.empty())

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -73,6 +73,16 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     else
         Command += Global.BinName;
 
+    // Info
+    bool Problem = false;
+
+    if (Streams.size() > 2 && !Global.License.IsSupported(Feature_MultipleTracks))
+    {
+        if (!Global.Quiet)
+            cerr << "*** More than 2 tracks is not supported by the current licence key. ***" << endl;
+        Problem = true;
+    }
+
     // Input
     for (size_t i = 0; i < Streams.size(); i++)
     {
@@ -90,7 +100,11 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
                 cerr << " (" << Streams[i].FileName_StartNumber << " --> " << Streams[i].FileName_EndNumber << ')' << endl;
             }
             cerr << "  " << Streams[i].Flavor << endl;
+            if (Streams[i].Problem)
+                cerr << "  *** This input format flavor is not supported by the current licence key. ***" << endl;
         }
+        if (Streams[i].Problem)
+            Problem = true;
 
         if (!Streams[i].Slices.empty())
         {
@@ -162,7 +176,15 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     }
 
     // Info
-    if (!Global.Quiet)
+    if (Problem)
+    {
+        cerr << "\nOne or more requested features are not supported with the current license key.\n";
+        cerr << "Please contact info@mediaarea.net for a quote or a temporary key." << endl;
+        if (!Global.IgnoreLicenseKey)
+            return 1;
+        cerr << "Ignoring the license for the moment." << endl;
+    }
+    if (!Global.Quiet || Problem)
     {
         cerr << endl;
     }

--- a/Source/CLI/Output.h
+++ b/Source/CLI/Output.h
@@ -27,6 +27,11 @@ struct stream
     string                      Flavor;
     string                      Slices;
     string                      FrameRate;
+    bool                        Problem;
+
+    stream()
+        : Problem(false)
+    {}
 };
 struct attachment
 {

--- a/Source/Lib/License.cpp
+++ b/Source/Lib/License.cpp
@@ -1,0 +1,409 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+*
+*  Use of this source code is governed by a BSD-style license that can
+*  be found in the License.html file in the root of the source tree.
+*/
+
+//---------------------------------------------------------------------------
+#include "Lib/License.h"
+#include "Lib/License_Internal.h"
+#include "Lib/Input_Base.h"
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+    #include <Shlobj.h>
+    #define PathSeparator "\\"
+#else
+    #include <sys/stat.h>
+    #define PathSeparator "/"
+#endif
+using namespace std;
+//---------------------------------------------------------------------------
+
+//***************************************************************************
+// Secure version of some OS calls
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+static string getenv_string(const char* name)
+{
+    #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) // TODO: getenv_s is supported with GCC only with C++17.
+        // Get size
+        size_t len;
+        if (getenv_s(&len, NULL, 0, name) || !len)
+            return string();
+
+        // Get value
+        char* value = new char[len * sizeof(char)];
+        if (getenv_s(&len, value, len, name))
+            return string();
+
+        // Create string
+        string valueString(value, len);
+        delete[] value;
+        return valueString;
+    #else
+        // FIXME: this is not secure
+        //struct _reent Reent;
+        //return string(&Reent, getenv_s(name));
+        const char* ToReturn = getenv(name);
+        if (ToReturn)
+            return ToReturn;
+        return string();
+    #endif
+}
+
+//---------------------------------------------------------------------------
+static tm localtime_tm(const time_t& time)
+{
+    tm result;
+    #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+        localtime_s(&result, &time);
+    #else
+        localtime_r(&time, &result);
+    #endif
+
+    return result;
+}
+
+//---------------------------------------------------------------------------
+bool CreateDirectory (const string& Dir)
+{
+    #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+        DWORD dwAttrib = GetFileAttributesA(Dir.c_str());
+        if (dwAttrib != INVALID_FILE_ATTRIBUTES && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY))
+            return false;
+        if (CreateDirectoryA(Dir.c_str(), NULL))
+            return false;
+        #else
+        struct stat s = { 0 };
+        if (!stat(Dir.c_str(), &s) && (s.st_mode & S_IFDIR))
+            return false;
+        if (!mkdir(Dir.c_str(), 0700))
+            return false;
+    #endif
+
+    cerr << "Problem while creating " << Dir << " directory" << endl;
+        
+    return true;
+}
+
+//---------------------------------------------------------------------------
+string GetLocalConfigPath (bool Create = false)
+{
+    string result;
+    #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+        char szPath[MAX_PATH];
+        if(SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_APPDATA, NULL, 0, szPath)))
+            result = szPath;
+    #else
+        result = getenv_string("HOME");
+        if (!result.empty())
+            result += '/';
+        result += ".config";
+    #endif
+
+    if (!result.empty())
+    {
+        if (Create)
+            CreateDirectory(result);
+        result += PathSeparator "RAWcooked";
+        if (Create)
+            CreateDirectory(result);
+    }
+    return result;
+}
+
+//***************************************************************************
+// License decode
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+class license_input : public input_base
+{
+public:
+    license_input() : input_base(), Supported(false) {}
+    bool Parse(bool AcceptTruncated = false, bool FullCheck = false);
+
+    license_internal* License;
+    bool Supported;
+};
+
+//---------------------------------------------------------------------------
+bool license_input::Parse(bool AcceptTruncated, bool FullCheck)
+{
+    // Place holder for license key descrambling - Begin
+    return true; // Not supported
+    // Place holder for license key descrambling - End
+}
+
+//---------------------------------------------------------------------------
+bool DecodeLicense(const string& FromUser, license_internal* License)
+{
+    // Size
+    if (FromUser.size()>200)
+    {
+        cerr << "Invalid size of license key." << endl;
+        return true;
+    }
+
+    // Analyze
+    uint8_t Buffer[100];
+    size_t Buffer_Offset = 0;
+    for (; Buffer_Offset < FromUser.size() / 2; Buffer_Offset++)
+    {
+        const char L1 = FromUser[Buffer_Offset * 2];
+        const char L2 = FromUser[Buffer_Offset * 2 + 1];
+        if (!((L1 >= '0' && L1 <= '9') || (L1 >= 'A' && L1 <= 'F'))
+            && !((L2 >= '0' && L2 <= '9') || (L2 >= 'A' && L2 <= 'F')))
+        {
+            cerr << "Invalid characters in license key." << endl;
+            return true;
+        }
+
+        Buffer[Buffer_Offset] = ((L1 - ((L1 <= '9') ? '0' : ('A' - 10))) << 4)
+            | ((L2 - ((L2 <= '9') ? '0' : ('A' - 10))));
+    }
+
+    // Parse
+    license_input Input;
+    Input.License = License;
+    Input.Buffer = Buffer;
+    Input.Buffer_Size = Buffer_Offset;
+    if (Input.Parse())
+    {
+        if (License && !Input.Supported)
+        {
+            cerr << "License detected but decoding not supported in this version." << endl;
+            *License = license_internal();
+            return false;
+        }
+        if (!License)
+            return !Input.Supported;
+        return true;
+    }
+    return false;
+}
+
+//***************************************************************************
+// license_internal
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+license_internal::license_internal()
+    : Date((time_t)-1)
+    , UserID(0)
+{
+    memset(License_Flags, 0x00, sizeof(License_Flags));
+    memset(Input_Flags, 0x00, sizeof(Input_Flags));
+
+    // Default license flags
+    for (size_t i = 0; DefaultLicense_Parsers[i].Value != (uint8_t)-1; i++)
+        AddFlavor(License_Flags[DefaultLicense_Parsers[i].Value], DefaultLicense_Parsers[i].Flavor);
+}
+
+void license_internal::AddFlavor(uint64_t &Value, uint8_t Flavor)
+{
+    Value |= (((uint64_t)1) << Flavor);
+}
+
+const char* license_internal::SupportedFlavor(uint64_t &Value, uint8_t Flavor)
+{
+    return (Value & (((uint64_t)1) << Flavor)) ? "Yes" : "No ";
+}
+
+//***************************************************************************
+// License class
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+license::license()
+{
+    Internal = new license_internal();
+}
+
+//---------------------------------------------------------------------------
+license::~license()
+{
+    delete (license_internal*)Internal;
+}
+
+//---------------------------------------------------------------------------
+void license::Feature(feature Value) { license_internal* License = (license_internal*)Internal; License->Input_Flags[0] |= ((uint64_t)1 << Value); }
+void license::Muxer(muxer Value) { license_internal* License = (license_internal*)Internal; License->Input_Flags[1] |= ((uint64_t)1 << Value); }
+void license::Encoder(encoder Value) { license_internal* License = (license_internal*)Internal; License->Input_Flags[2] |= ((uint64_t)1 << Value); }
+
+//---------------------------------------------------------------------------
+bool license::LoadLicense(string LicenseKey, bool StoreLicenseKey)
+{
+    // Read license from environment variable
+    if (LicenseKey.empty())
+        LicenseKey = getenv_string("RAWcooked_License");
+
+    // Read license from a file
+    if (LicenseKey.empty())
+    {
+        string Path = GetLocalConfigPath() + PathSeparator "Config.txt";
+        ifstream F(Path);
+        string temp;
+        while (!F.fail() && !F.eof())
+        {
+            F >> temp;
+            if (temp.rfind("License=", 8) == 0 || temp.rfind("Licence=", 8) == 0)
+                LicenseKey = temp.substr(8);
+        }
+    }
+
+    // Decode
+    if (!LicenseKey.empty())
+    {
+        if (DecodeLicense(LicenseKey, (license_internal*)Internal))
+            return true;
+        
+        if (StoreLicenseKey)
+        {
+            string Path = GetLocalConfigPath(true);
+            Path += PathSeparator "Config.txt";
+            fstream F(Path, std::fstream::in | std::fstream::out);
+            if (!F.is_open())
+            {
+                F.open(Path, ios_base::app);
+                if (!F.is_open())
+                {
+                    cerr << "Can not open " << Path << '.' << endl;
+                    return true;
+                }
+            }
+            else
+            {
+                F.seekp(-1, ios_base::end);
+                if (!F.fail())
+                {
+                    char temp;
+                    F.read(&temp, 1);
+                    if (F.fail())
+                    {
+                        cerr << "Can not read in " << Path << '.' << endl;
+                        return true;
+                    }
+                    if (!F.fail() && !F.eof() && temp != '\n')
+                    {
+                        F.seekp(0, ios_base::end);
+                        F.write("\n", 1); // endl;
+                        if (F.fail())
+                        {
+                            cerr << "Can not write in " << Path << '.' << endl;
+                            return true;
+                        }
+                    }
+                    else
+                        F.seekp(0, ios_base::end);
+                }
+            }
+            F.write(string("License=" + LicenseKey + '\n').c_str(), 9 + LicenseKey.size());
+            if (F.fail())
+            {
+                cerr << "Can not write in " << Path << '.' << endl;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+//---------------------------------------------------------------------------
+void license::ShowLicense(bool Verbose)
+{
+    license_internal* License = (license_internal*)Internal;
+
+    // UserID
+    if (License->UserID)
+    {
+        if (Verbose)
+        {
+            cerr << "License owner ID = " << License->UserID << '.';
+            if (License->Date == (time_t)-1)
+                cerr << '\n' << endl;
+            else
+                cerr << ' ';
+        }
+    }
+    else if (License->Date == (time_t)-1)
+        cerr << "Using default license.\nConsider to support RAWcooked: https://MediaArea.net/RAWcooked\n" << endl;
+
+    // Date
+    if (License->Date != (time_t)-1)
+    {
+        struct tm TimeInfo = localtime_tm(License->Date);
+        cerr << "Temporary license, valid until " << TimeInfo.tm_year + 1900 << '-' << setfill('0') << setw(2) << TimeInfo.tm_mon + 1 << '-' << setfill('0') << setw(2) << TimeInfo.tm_mday << ".\n" ;
+
+        time_t Time;
+        time(&Time);
+        if (Time > License->Date)
+        {
+            cerr << "Outdated license, using default license.\n";
+            *License = license_internal();
+        }
+
+        cerr << endl;
+    }
+
+    if (!Verbose)
+        return;
+
+    // Info
+    for (size_t i = 0; Infos[i].Name; i++)
+    {
+        cerr << "Licensed " << Infos[i].Name << ':' << endl;
+        for (int8_t j = 0; j < Infos[i].Size; j++)
+        {
+            const char* Supported = License->SupportedFlavor(License->License_Flags[i], j);
+            cerr << Supported << ' ' << Infos[i].Flavor_String(j) << endl;
+        }
+        cerr << endl;
+    }
+}
+
+//---------------------------------------------------------------------------
+bool license::IsSupported()
+{
+    license_internal* License = (license_internal*)Internal;
+
+    // Info
+    for (int8_t i = 0; i < 3; i++)
+        for (int8_t j = 0; j < Infos[i].Size; j++)
+            if (License->Input_Flags[i] & ((uint64_t)1 << j) && License->SupportedFlavor(License->License_Flags[i], j)[0] != 'Y')
+                return false;
+    
+    return true;
+}
+
+//---------------------------------------------------------------------------
+bool license::IsSupported(feature Feature)
+{
+    license_internal* License = (license_internal*)Internal;
+
+    const char* Supported = License->SupportedFlavor(License->License_Flags[0], Feature);
+    return Supported[0] == 'Y';
+}
+
+//---------------------------------------------------------------------------
+bool license::IsSupported(parser Parser, uint8_t Style)
+{
+    license_internal* License = (license_internal*)Internal;
+
+    const char* Supported = License->SupportedFlavor(License->License_Flags[3 + Parser], Style);
+    return Supported[0] == 'Y';
+}
+
+//---------------------------------------------------------------------------
+bool license::IsSupported_License()
+{
+    string LicenseKey;
+    return !DecodeLicense(LicenseKey, NULL);
+}

--- a/Source/Lib/License.h
+++ b/Source/Lib/License.h
@@ -1,0 +1,76 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+*
+*  Use of this source code is governed by a BSD-style license that can
+*  be found in the License.html file in the root of the source tree.
+*/
+
+//---------------------------------------------------------------------------
+#ifndef LicenseH
+#define LicenseH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include <cstdint>
+#include <string>
+#include <Lib/Input_Base.h>
+using namespace std;
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Features
+enum feature : uint8_t
+{
+    Feature_GeneralOptions,
+    Feature_InputOptions,
+    Feature_EncodingOptions,
+    Feature_MultipleTracks,
+    Feature_Max,
+};
+
+//---------------------------------------------------------------------------
+// Muxer
+enum muxer : uint8_t
+{
+    Muxer_Matroska,
+    Muxer_Max,
+};
+
+//---------------------------------------------------------------------------
+// Encoder
+enum encoder : uint8_t
+{
+    Encoder_FFV1,
+    Encoder_PCM,
+    Encoder_FLAC,
+    Encoder_Max,
+};
+
+//---------------------------------------------------------------------------
+struct license
+{
+public:
+    // Constructor/Destructor
+    license();
+    ~license();
+
+    // Set license info
+    void Feature(feature Value);
+    void Muxer(muxer Value);
+    void Encoder(encoder Value);
+
+    // License management
+    bool LoadLicense(string LicenseKey, bool StoreLicenseKey);
+    void ShowLicense(bool Verbose=false);
+
+    // Checks
+    bool IsSupported();
+    bool IsSupported(feature Feature);
+    bool IsSupported(parser Parser, uint8_t Flavor);
+    bool IsSupported_License();
+
+private:
+    // Internal
+    void*       Internal;
+};
+
+#endif

--- a/Source/Lib/License_Internal.h
+++ b/Source/Lib/License_Internal.h
@@ -1,0 +1,110 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+*
+*  Use of this source code is governed by a BSD-style license that can
+*  be found in the License.html file in the root of the source tree.
+*/
+
+//---------------------------------------------------------------------------
+#ifndef License_ListH
+#define License_ListH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "Lib/DPX/DPX.h"
+#include "Lib/WAV/WAV.h"
+#include "Lib/License.h"
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Default license content
+struct default_license_values
+{
+    uint8_t         Value;
+    uint8_t         Flavor;
+};
+static default_license_values DefaultLicense_Parsers[] =
+{
+    { 1                 , Muxer_Matroska                },
+    { 2                 , Encoder_FFV1                  },
+    { 2                 , Encoder_FLAC                  },
+    { 3 + Parser_DPX    , dpx::Raw_RGB_8                },
+    { 3 + Parser_DPX    , dpx::Raw_RGB_10_FilledA_LE    },
+    { 3 + Parser_DPX    , dpx::Raw_RGB_10_FilledA_BE    },
+    { 3 + Parser_WAV    , wav::PCM_48000_16_2_LE        },
+    { (uint8_t)-1       , (uint8_t)-1                   },
+};
+
+//---------------------------------------------------------------------------
+struct feature_info
+{
+    const char*     Name;
+};
+const feature_info FeatureInfos[Feature_Max + 1] =
+{
+    { "General options"         },
+    { "Input options"           },
+    { "Encoding options"        },
+    { "More than 2 tracks"      },
+    { NULL                      },
+};
+
+//---------------------------------------------------------------------------
+struct muxer_info
+{
+    const char*     Name;
+};
+const muxer_info MuxerInfos[Muxer_Max] =
+{
+    { "Matroska"    },
+};
+
+//---------------------------------------------------------------------------
+struct encoder_info
+{
+    const char*     Name;
+};
+const encoder_info EncoderInfos[Encoder_Max] =
+{
+    { "FFV1"        },
+    { "PCM"         },
+    { "FLAC"        },
+};
+
+//---------------------------------------------------------------------------
+static string Features_String(uint8_t Value) { return FeatureInfos[Value].Name; }
+static string Muxers_String(uint8_t Value) { return MuxerInfos[Value].Name; }
+static string Encoders_String(uint8_t Value) { return EncoderInfos[Value].Name; }
+typedef string (*flavor_string) (uint8_t Flavor);
+struct parser_info
+{
+    const char*     Name;
+    uint8_t         Size;
+    flavor_string   Flavor_String;
+};
+static const parser_info Infos[3 + Parser_Max + 1] =
+{
+    { "features"            , Feature_Max           , Features_String       },
+    { "muxers/demuxers"     , Muxer_Max             , Muxers_String         },
+    { "encoders/decoders"   , Encoder_Max           , Encoders_String       },
+    { "DPX flavors"         , dpx::Style_Max        , DPX_Flavor_String     },
+    { "WAV flavors"         , wav::Style_Max        , WAV_Flavor_String     },
+    { NULL                  , 0                     , NULL                  },
+};
+
+//---------------------------------------------------------------------------
+struct license_internal
+{
+    time_t              Date;
+    uint64_t            UserID;
+    uint64_t            License_Flags[3 + Parser_Max];
+
+    license_internal();
+
+    static void         AddFlavor(uint64_t &Value, uint8_t Flavor);
+    static const char*  SupportedFlavor(uint64_t &Value, uint8_t Flavor);
+
+    // License info
+    uint8_t             Input_Flags[3];
+};
+
+#endif


### PR DESCRIPTION
License can be stored:
- using an environment variable `RAWcooked_License=XXXXXX`
- in `~/.config/RAWcooked/Config.txt` (can be created through `rawcooked --store-license XXXXXX`)

License contains an entity ID, a date (for temporary license), licensed features and format flavors.

by default, `rawcooked --show-license` is:

```
No license found, using default license.
Consider to support RAWcooked: https://MediaArea.net/RAWcooked

Licensed features:
No  General options
No  Input options
No  Encoding options
No  More than 2 tracks

Licensed muxers/demuxers:
Yes Matroska

Licensed encoders/decoders:
Yes FFV1
No  PCM
Yes FLAC

Licensed DPX flavors:
Yes DPX/Raw/RGB/8bit
Yes DPX/Raw/RGB/10bit/FilledA/LE
Yes DPX/Raw/RGB/10bit/FilledA/BE
No  DPX/Raw/RGB/12bit/Packed/BE
No  DPX/Raw/RGB/12bit/FilledA/BE
No  DPX/Raw/RGB/12bit/FilledA/LE
No  DPX/Raw/RGB/16bit/BE
No  DPX/Raw/RGB/16bit/LE
No  DPX/Raw/RGBA/8bit
No  DPX/Raw/RGBA/10bit/FilledA/LE
No  DPX/Raw/RGBA/10bit/FilledA/BE
No  DPX/Raw/RGBA/12bit/Packed/BE
No  DPX/Raw/RGBA/12bit/FilledA/BE
No  DPX/Raw/RGBA/12bit/FilledA/LE
No  DPX/Raw/RGBA/16bit/BE
No  DPX/Raw/RGBA/16bit/LE

Licensed WAV flavors:
No  WAV/PCM/44kHz/8bit/1ch/U
No  WAV/PCM/44kHz/8bit/2ch/U
No  WAV/PCM/44kHz/8bit/6ch/U
No  WAV/PCM/44kHz/16bit/1ch/LE
No  WAV/PCM/44kHz/16bit/2ch/LE
No  WAV/PCM/44kHz/16bit/6ch/LE
No  WAV/PCM/44kHz/24bit/1ch/LE
No  WAV/PCM/44kHz/24bit/2ch/LE
No  WAV/PCM/44kHz/24bit/6ch/LE
No  WAV/PCM/48kHz/8bit/1ch/U
No  WAV/PCM/48kHz/8bit/2ch/U
No  WAV/PCM/48kHz/8bit/6ch/U
No  WAV/PCM/48kHz/16bit/1ch/LE
Yes WAV/PCM/48kHz/16bit/2ch/LE
No  WAV/PCM/48kHz/16bit/6ch/LE
No  WAV/PCM/48kHz/24bit/1ch/LE
No  WAV/PCM/48kHz/24bit/2ch/LE
No  WAV/PCM/48kHz/24bit/6ch/LE
No  WAV/PCM/96kHz/8bit/1ch/U
No  WAV/PCM/96kHz/8bit/2ch/U
No  WAV/PCM/96kHz/8bit/6ch/U
No  WAV/PCM/96kHz/16bit/1ch/LE
No  WAV/PCM/96kHz/16bit/2ch/LE
No  WAV/PCM/96kHz/16bit/6ch/LE
No  WAV/PCM/96kHz/24bit/1ch/LE
No  WAV/PCM/96kHz/24bit/2ch/LE
No  WAV/PCM/96kHz/24bit/6ch/LE
```