### PR TITLE
nicer output

### DIFF
--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -1,4 +1,8 @@
 .TH "RAWcooked" "1" "https://mediaarea.net/RAWcooked" "18.07" "Bit\-by\-bit fidelity"
+.\" Turn off justification for nroff.
+.if n .ad l
+.\" Turn off hyphenation.
+.nh
 .SH NAME
 \fBRAWcooked\fR \- encode and decode audio\-visual RAW data with Matroska, FFV1 and FLAC
 .SH SYNOPSIS


### PR DESCRIPTION
- turn off justification for nroff
- turn off hyphenation, because it makes many mistakes in technical documents