### PR TITLE
Accept any even count of padding bytes in WAV fmt chunk

### DIFF
--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -14,3 +14,4 @@ Features/FileNaming/000dpx+000wav All
 Features/FileNaming 000dpx+000wav
 Formats/WAV/Features 2ExtraNullBytesInFmtChunk
 Formats/WAV/Features 4ExtraNullBytesInFmtChunk
+Formats/WAV/Features 24ExtraNullBytesInFmtChunk

--- a/Source/Lib/WAV/WAV.cpp
+++ b/Source/Lib/WAV/WAV.cpp
@@ -260,19 +260,10 @@ void wav::WAVE_fmt_()
     }
     if (FormatTag == 1)
     {
-        if (Levels[Level].Offset_End == Buffer_Offset + 2)
+        // Some files have zeroes after actual fmt content, it does not hurt so we accept them
+        while (Buffer_Offset + 2 <= Levels[Level].Offset_End)
         {
-            uint16_t Padding0 = Get_L2(); // Some files have 2 zeroes, it does not hurt so we accept them
-            if (Padding0)
-            {
-                Unsupported("WAV FormatTag extension");
-                return;
-            }
-        }
-
-        if (Levels[Level].Offset_End == Buffer_Offset + 4)
-        {
-            uint32_t Padding0 = Get_L4(); // Some files have 4 zeroes, it does not hurt so we accept them
+            uint16_t Padding0 = Get_L2(); 
             if (Padding0)
             {
                 Unsupported("WAV FormatTag extension");


### PR DESCRIPTION
I got several files from users with arbitrary count of NULL bytes in the WAV `fmt ` chunk, no idea about the reason behind but it does not hurt so we accept them.