### PR TITLE
Remove AVX2 by default on Windows release

### DIFF
--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
@@ -268,7 +268,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Fix https://github.com/MediaArea/RAWcooked/issues/188