### PR TITLE
Centralize and permit multiple error messages from parsers

### DIFF
--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -10,6 +10,7 @@ rawcooked_SOURCES = \
     ../../../Source/Lib/AIFF/AIFF.cpp \
     ../../../Source/Lib/CRC32/ZenCRC32.cpp \
     ../../../Source/Lib/DPX/DPX.cpp \
+    ../../../Source/Lib/Errors.cpp \
     ../../../Source/Lib/FileIO.cpp \
     ../../../Source/Lib/FFV1/Coder/FFV1_Coder_GolombRice.cpp \
     ../../../Source/Lib/FFV1/Coder/FFV1_Coder_RangeCoder.cpp \

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="..\..\..\Source\Lib\Config.h" />
     <ClInclude Include="..\..\..\Source\Lib\CRC32\ZenCRC32.h" />
     <ClInclude Include="..\..\..\Source\Lib\DPX\DPX.h" />
+    <ClInclude Include="..\..\..\Source\Lib\Errors.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_GolombRice.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_RangeCoder.h" />
@@ -88,6 +89,7 @@
     <ClCompile Include="..\..\..\Source\Lib\AIFF\AIFF.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\CRC32\ZenCRC32.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\DPX\DPX.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\Errors.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_GolombRice.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_RangeCoder.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\FFV1_Frame.cpp" />

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClInclude Include="..\..\..\Source\Lib\AIFF\AIFF.h">
       <Filter>Header Files\AIFF</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\Errors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\CRC32\ZenCRC32.cpp">
@@ -421,6 +424,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\AIFF\AIFF.cpp">
       <Filter>Source Files\AIFF</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\Errors.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="..\..\..\Source\Lib\Config.h" />
     <ClInclude Include="..\..\..\Source\Lib\CRC32\ZenCRC32.h" />
     <ClInclude Include="..\..\..\Source\Lib\DPX\DPX.h" />
+    <ClInclude Include="..\..\..\Source\Lib\Errors.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_GolombRice.h" />
     <ClInclude Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_RangeCoder.h" />
@@ -88,6 +89,7 @@
     <ClCompile Include="..\..\..\Source\Lib\AIFF\AIFF.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\CRC32\ZenCRC32.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\DPX\DPX.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\Errors.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_GolombRice.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\Coder\FFV1_Coder_RangeCoder.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\FFV1\FFV1_Frame.cpp" />

--- a/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClInclude Include="..\..\..\Source\Lib\AIFF\AIFF.h">
       <Filter>Header Files\AIFF</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\Errors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\CRC32\ZenCRC32.cpp">
@@ -421,6 +424,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\AIFF\AIFF.cpp">
       <Filter>Source Files\AIFF</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\Errors.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -542,5 +542,5 @@ void global::ProgressIndicator_Show()
 
     // Show summary
     cerr << '\r';
-    cerr << "                              \r"; // Clean up in case there is less content outputed than the previous time
+    cerr << "                                                            \r"; // Clean up in case there is less content outputed than the previous time
 }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -45,6 +45,7 @@ public:
     size_t                      Path_Pos_Global;
     vector<string>              Inputs;
     license                     License;
+    errors                      Errors;
 
     // Options
     int ManageCommandLine(const char* argv[], int argc);

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -190,7 +190,7 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     }
 
     if (Global.DisplayCommand)
-        cout << Command << endl;
+        cout << Command;
     else
     {
         if (int Value = system(Command.c_str()))

--- a/Source/Lib/AIFF/AIFF.h
+++ b/Source/Lib/AIFF/AIFF.h
@@ -16,10 +16,16 @@
 #include <cstddef>
 //---------------------------------------------------------------------------
 
+namespace aiff_issue
+{
+    namespace undecodable { enum code : uint8_t; }
+    namespace unsupported { enum code : uint8_t; }
+}
+
 class aiff : public input_base_uncompressed
 {
 public:
-    aiff();
+    aiff(errors* Errors = nullptr);
 
     string                      Flavor_String();
 
@@ -70,7 +76,7 @@ public:
         PCM_96000_24_1_BE,
         PCM_96000_24_2_BE,
         PCM_96000_24_6_BE,
-        Style_Max,
+        Flavor_Max,
     };
     enum endianess
     {
@@ -91,7 +97,11 @@ public:
     static const char* Endianess_String(flavor Flavor);
 
 private:
-    bool                        ParseBuffer();
+    void                        ParseBuffer();
+    void                        BufferOverflow();
+    void                        Undecodable(aiff_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
+    void                        Unsupported(aiff_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
+
     typedef void (aiff::*call)();
     typedef call (aiff::*name)(uint64_t);
 

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -16,10 +16,17 @@
 #include <cstddef>
 //---------------------------------------------------------------------------
 
+namespace dpx_issue
+{
+    namespace undecodable { enum code : uint8_t; }
+    namespace unsupported { enum code : uint8_t; }
+    namespace invalid     { enum code : uint8_t; }
+}
+
 class dpx : public input_base_uncompressed
 {
 public:
-    dpx();
+    dpx(errors* Errors = nullptr);
 
     string                      Flavor_String();
 
@@ -48,7 +55,7 @@ public:
         Raw_RGBA_12_FilledA_LE,
         Raw_RGBA_16_BE,
         Raw_RGBA_16_LE,
-        Style_Max,
+        Flavor_Max,
     };
 
     enum endianess : uint8_t
@@ -99,7 +106,10 @@ public:
     static const char* Endianess_String(flavor Flavor);
 
 private:
-    bool                        ParseBuffer();
+    void                        ParseBuffer();
+    void                        BufferOverflow();
+    void                        Undecodable(dpx_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
+    void                        Unsupported(dpx_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
 };
 
 string DPX_Flavor_String(uint8_t Flavor);

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -1,0 +1,174 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+#include "Lib/FileIO.h"
+#include "Lib/Input_Base.h"
+#include <cmath>
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+namespace dpx_issue { extern const char** ErrorTexts[]; }
+namespace tiff_issue { extern const char** ErrorTexts[]; }
+namespace wav_issue { extern const char** ErrorTexts[]; }
+namespace aiff_issue { extern const char** ErrorTexts[]; }
+namespace matroska_issue { extern const char** ErrorTexts[]; }
+namespace file_issue { extern const char** ErrorTexts[]; }
+static const char*** AllErrorTexts[] =
+{
+    dpx_issue::ErrorTexts,
+    tiff_issue::ErrorTexts,
+    wav_issue::ErrorTexts,
+    aiff_issue::ErrorTexts,
+    matroska_issue::ErrorTexts,
+    NULL,
+};
+static_assert(Parser_Max == sizeof(AllErrorTexts) / sizeof(const char***), IncoherencyMessage); \
+
+
+//---------------------------------------------------------------------------
+static const char* ParserNames[] =
+{
+    "DPX",
+    "TIFF",
+    "WAV",
+    "AIFF",
+    "Matroska",
+    "RAWcooked license",
+};
+static_assert(Parser_Max == sizeof(ParserNames) / sizeof(const char*), IncoherencyMessage); \
+
+//---------------------------------------------------------------------------
+static const char* ErrorTypes_Strings[] =
+{
+    "Error: undecodable",
+    "Error: unsupported",
+};
+static_assert(error::Type_Max == sizeof(ErrorTypes_Strings) / sizeof(const char*), IncoherencyMessage); \
+
+//---------------------------------------------------------------------------
+static const char* ErrorTypes_Infos[] =
+{
+    NULL,
+    "Please contact info@mediaarea.net if you want support of such content",
+};
+static_assert(error::Type_Max == sizeof(ErrorTypes_Infos) / sizeof(const char*), IncoherencyMessage); \
+
+//---------------------------------------------------------------------------
+const char* errors::ErrorMessage()
+{
+    if (Parsers.empty())
+        return NULL;
+
+    ErrorMessageCache.clear();
+
+    bitset<error::Type_Max> HasErrors;
+
+    for (uint8_t i = 0; i < Parsers.size(); i++)
+        for (uint8_t j = 0; j < error::Type_Max; j++)
+        {
+            for (uint8_t k = 0; k < Parsers[i].Codes[j].size(); k++)
+                if (i < Parser_Max)
+                {
+                    if (Parsers[i].Codes[j][k].Count)
+                    {
+                        HasErrors.set(j);
+                        ErrorMessageCache += ErrorTypes_Strings[j];
+                        ErrorMessageCache += ' ';
+                        ErrorMessageCache += ParserNames[i];
+                        ErrorMessageCache += ' ';
+                        if (AllErrorTexts[i] && AllErrorTexts[i][j] && AllErrorTexts[i][j][k])
+                            ErrorMessageCache += AllErrorTexts[i][j][k];
+                        else
+                            ErrorMessageCache += to_string(k);
+                        if (Parsers[i].Codes[j][k].Count > 1)
+                        {
+                            ErrorMessageCache += " (x";
+                            ErrorMessageCache += to_string(Parsers[i].Codes[j][k].Count);
+                            ErrorMessageCache += ')';
+                        }
+                        ErrorMessageCache += '.';
+                        ErrorMessageCache += '\n';
+                    }
+                }
+                else if (i == Parser_FileWriter)
+                {
+                    if (Parsers[i].Codes[j][k].StringList)
+                    {
+                        ErrorMessageCache += "Error: ";
+                        ErrorMessageCache += file_issue::ErrorTexts[j][k];
+                        ErrorMessageCache += '.';
+                        ErrorMessageCache += '\n';
+                        std::vector<string>& List = *Parsers[i].Codes[j][k].StringList;
+                        for (size_t l = 0; l < List.size(); l++)
+                        {
+                            ErrorMessageCache += "       ";
+                            ErrorMessageCache += List[l];
+                            ErrorMessageCache += '\n';
+                        }
+                    }
+                }
+        }
+    for (uint8_t j = 0; j < error::Type_Max; j++)
+        if (ErrorTypes_Infos[j] && HasErrors[j])
+        {
+            ErrorMessageCache += ErrorTypes_Infos[j];
+            ErrorMessageCache += '.';
+            ErrorMessageCache += '\n';
+        }
+
+    return ErrorMessageCache.c_str();
+}
+
+//---------------------------------------------------------------------------
+void errors::Error(parser Parser, error::type Type, error::generic::code Code)
+{
+    if (Parser >= Parsers.size())
+        Parsers.resize(Parser + 1);
+    std::vector<per_parser::info> & Codes = Parsers[Parser].Codes[Type];
+    if (Code >= Codes.size())
+        Codes.resize(Code + 1);
+
+    Codes[Code].Count++;
+    if ((Type == error::Undecodable || Type == error::Unsupported) && !HasErrors_Value)
+        HasErrors_Value = true;
+}
+
+//---------------------------------------------------------------------------
+void errors::Error(parser Parser, error::type Type, error::generic::code Code, const string& String)
+{
+    if (Parser >= Parsers.size())
+        Parsers.resize(Parser + 1);
+    std::vector<per_parser::info> & Codes = Parsers[Parser].Codes[Type];
+    if (Code >= Codes.size())
+        Codes.resize(Code + 1);
+
+    if (!Codes[Code].StringList)
+        Codes[Code].StringList = new std::vector<string>;
+    std::vector<string>& List = *Codes[Code].StringList;
+    if (List.size() >= 11)
+        return;
+    if (List.size() >= 10)
+    {
+        List.push_back("...");
+        return;
+    }
+    if (!List.empty() && List.back() == String)
+        return;
+    List.push_back(String);
+    if ((Type == error::Undecodable || Type == error::Unsupported) && !HasErrors_Value)
+        HasErrors_Value = true;
+}
+
+//---------------------------------------------------------------------------
+void errors::DeleteStrings()
+{
+    for (uint8_t i = Parser_Max + 1; i < Parsers.size(); i++)
+        for (uint8_t j = 0; j < error::Type_Max; j++)
+            for (uint8_t k = 0; k < Parsers[i].Codes[j].size(); k++)
+                delete Parsers[i].Codes[j][k].StringList;
+}
+

--- a/Source/Lib/Errors.h
+++ b/Source/Lib/Errors.h
@@ -1,0 +1,103 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+ //---------------------------------------------------------------------------
+#ifndef ErrorsH
+#define ErrorsH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include <bitset>
+#include <cstdint>
+#include <string>
+#include <vector>
+using namespace std;
+class rawcooked;
+class filemap;
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Parser codes
+
+enum parser
+{
+    Parser_DPX,
+    Parser_TIFF,
+    Parser_WAV,
+    Parser_AIFF,
+    Parser_Matroska,
+    Parser_License,
+    Parser_Max, // After this line, parsers are not really parsers and must be specifically handled
+    Parser_FileWriter,
+};
+
+namespace error
+{
+    enum type : uint8_t
+    {
+        Undecodable,
+        Unsupported,
+        Type_Max
+    };
+
+    namespace common
+    {
+        enum code : uint8_t;
+        extern const char* MessageText[];
+    }
+    namespace undecodable
+    {
+        enum code : uint8_t;
+    }
+    namespace unsupported
+    {
+        enum code : uint8_t;
+    }
+    namespace generic
+    {
+        enum code : uint8_t;
+    }
+    extern const char*** ErrorTexts[];
+}
+
+//---------------------------------------------------------------------------
+// Helpers
+
+#define IncoherencyMessage "Incoherency between enums and message strings"
+
+//---------------------------------------------------------------------------
+class errors
+{
+public:
+    // Constructor / Destructor
+    ~errors()                   { if (Parsers.size() > Parser_Max) DeleteStrings(); }
+    
+    // Error message read
+    const char*                 ErrorMessage();
+
+    // Error message write
+    void                        Error(parser Parser, error::type Type, error::generic::code Code);
+    void                        Error(parser Parser, error::type Type, error::generic::code Code, const string& String);
+    bool                        HasErrors() { return HasErrors_Value; }
+    void                        ClearErrors() { Parsers.clear(); }
+
+private:
+    struct per_parser
+    {
+        union info
+        {
+            size_t              Count;
+            std::vector<string>*StringList;
+        };
+        std::vector<info>       Codes[error::Type_Max];
+    };
+    std::vector<per_parser>     Parsers;
+    string                      ErrorMessageCache;
+    void                        DeleteStrings();
+    bool                        HasErrors_Value = false;
+};
+
+#endif

--- a/Source/Lib/FileIO.h
+++ b/Source/Lib/FileIO.h
@@ -12,6 +12,7 @@
 //---------------------------------------------------------------------------
 #include "CLI/Config.h"
 #include "CLI/Global.h"
+#include "Lib/Errors.h"
 #include "Lib/RawFrame/RawFrame.h"
 #include <string>
 #include <vector>
@@ -37,6 +38,26 @@ public:
 
 private:
     void*                       Private;
+};
+
+class file
+{
+public:
+    // Constructor/Destructor
+                                ~file() { Close(); }
+
+    // Actions
+    bool                        Open(const string& BaseDirectory_Source, const string& OutputFileName_Source, const char* Mode);
+    bool                        IsOpen() { return Private ? true : false; }
+    bool                        Write(const void* Buffer, size_t Size);
+    bool                        Close();
+
+    // Errors
+    errors*                     Errors = NULL;
+
+private:
+    void*                       Private = NULL;
+    string                      OutputFileName;
 };
 
 #endif

--- a/Source/Lib/License.cpp
+++ b/Source/Lib/License.cpp
@@ -126,21 +126,26 @@ string GetLocalConfigPath (bool Create = false)
 class license_input : public input_base
 {
 public:
-    license_input() : input_base(), Supported(false) {}
+    license_input() : input_base(Parser_License), Supported(false) {}
 
     license_internal* License;
     bool Supported;
 
 private:
-    bool                        ParseBuffer();
+    void                        ParseBuffer();
+    void                        BufferOverflow();
 };
 
 //---------------------------------------------------------------------------
-bool license_input::ParseBuffer()
+void license_input::ParseBuffer()
 {
     // Place holder for license key descrambling - Begin
-    return true; // Not supported
     // Place holder for license key descrambling - End
+}
+
+//---------------------------------------------------------------------------
+void license_input::BufferOverflow()
+{
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/License_Internal.h
+++ b/Source/Lib/License_Internal.h
@@ -88,10 +88,10 @@ static const parser_info Infos[3 + Parser_Max + 1] =
     { "features"            , Feature_Max           , Features_String       },
     { "muxers/demuxers"     , Muxer_Max             , Muxers_String         },
     { "encoders/decoders"   , Encoder_Max           , Encoders_String       },
-    { "DPX flavors"         , dpx::Style_Max        , DPX_Flavor_String     },
-    { "TIFF flavors"        , tiff::Style_Max       , TIFF_Flavor_String    },
-    { "WAV flavors"         , wav::Style_Max        , WAV_Flavor_String     },
-    { "AIFF flavors"        , aiff::Style_Max       , AIFF_Flavor_String    },
+    { "DPX flavors"         , dpx::Flavor_Max        , DPX_Flavor_String     },
+    { "TIFF flavors"        , tiff::Flavor_Max       , TIFF_Flavor_String    },
+    { "WAV flavors"         , wav::Flavor_Max        , WAV_Flavor_String     },
+    { "AIFF flavors"        , aiff::Flavor_Max       , AIFF_Flavor_String    },
     { NULL                  , 0                     , NULL                  },
 };
 

--- a/Source/Lib/RAWcooked/RAWcooked.h
+++ b/Source/Lib/RAWcooked/RAWcooked.h
@@ -10,6 +10,8 @@
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
+#include "Lib/Errors.h"
+#include "Lib/FileIO.h"
 #include <cstdint>
 #include <cstddef>
 #include <string>
@@ -41,11 +43,14 @@ public:
     string                      OutputFileName;
     uint64_t                    FileSize;
 
+    // Errors
+    errors*                     Errors = NULL;
+
 private:
     uint64_t                    Buffer_Offset;
 
     // File IO
-    FILE*                       F;
+    file                        File;
     size_t                      BlockCount;
     void WriteToDisk(uint8_t* Buffer, size_t Buffer_Size);
 

--- a/Source/Lib/TIFF/TIFF.h
+++ b/Source/Lib/TIFF/TIFF.h
@@ -18,10 +18,16 @@
 #include <cstddef>
 //---------------------------------------------------------------------------
 
+namespace tiff_issue
+{
+    namespace undecodable { enum code : uint8_t; }
+    namespace unsupported { enum code : uint8_t; }
+}
+
 class tiff : public input_base_uncompressed
 {
 public:
-    tiff();
+    tiff(errors* Errors = NULL);
 
     string                      Flavor_String();
 
@@ -39,7 +45,7 @@ public:
         Raw_RGB_16_U_LE,
         Raw_RGBA_8_U,
         Raw_RGBA_16_U_LE,
-        Style_Max,
+        Flavor_Max,
     };
 
     enum endianess : uint8_t
@@ -125,7 +131,10 @@ public:
     std::set<data_content> DataContents;
 
 private:
-    bool                        ParseBuffer();
+    void                        ParseBuffer();
+    void                        BufferOverflow();
+    void                        Undecodable(tiff_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
+    void                        Unsupported(tiff_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
 };
 
 string TIFF_Flavor_String(uint8_t Flavor);

--- a/Source/Lib/WAV/WAV.h
+++ b/Source/Lib/WAV/WAV.h
@@ -16,10 +16,16 @@
 #include <cstddef>
 //---------------------------------------------------------------------------
 
+namespace wav_issue
+{
+    namespace undecodable { enum code : uint8_t; }
+    namespace unsupported { enum code : uint8_t; }
+}
+
 class wav : public input_base_uncompressed
 {
 public:
-    wav();
+    wav(errors* Errors = NULL);
 
     string                      Flavor_String();
 
@@ -52,7 +58,7 @@ public:
         PCM_96000_24_1_LE,
         PCM_96000_24_2_LE,
         PCM_96000_24_6_LE,
-        Style_Max,
+        Flavor_Max,
     };
     enum endianess
     {
@@ -73,7 +79,10 @@ public:
     static const char* Endianess_String(flavor Flavor);
 
 private:
-    bool                        ParseBuffer();
+    void                        ParseBuffer();
+    void                        BufferOverflow();
+    void                        Undecodable(wav_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
+    void                        Unsupported(wav_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
     typedef void (wav::*call)();
     typedef call (wav::*name)(uint64_t);
 


### PR DESCRIPTION
Also show errors when file reading or file writing fails (previously errors were silently ignored).
And split errors between parsing errors and unsupported content.