### PR TITLE
Check file instead of writing it if it already exists

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -219,6 +219,13 @@ int global::SetOption(const char* argv[], int& i, int argc)
         }
         return Error_NotTested(argv[i - 1], argv[i]);
     }
+    if (strcmp(argv[i], "-n") == 0)
+    {
+        OutputOptions["-n"] = string();
+        Mode = AlwaysNo; // Also RAWcooked itself
+        License.Feature(Feature_GeneralOptions);
+        return 0;
+    }
     if (!strcmp(argv[i], "-slicecrc"))
     {
         if (++i >= argc)
@@ -251,6 +258,13 @@ int global::SetOption(const char* argv[], int& i, int argc)
         if (++i >= argc)
             return Error_NotTested(argv[i - 1]);
         OutputOptions["threads"] = argv[i];
+        License.Feature(Feature_GeneralOptions);
+        return 0;
+    }
+    if (strcmp(argv[i], "-y") == 0)
+    {
+        OutputOptions["-y"] = string();
+        Mode = AlwaysYes; // Also RAWcooked itself
         License.Feature(Feature_GeneralOptions);
         return 0;
     }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -11,6 +11,7 @@
 
 //---------------------------------------------------------------------------
 #include "CLI/Config.h"
+#include "Lib/Config.h"
 #include "Lib/License.h"
 #include <map>
 #include <vector>
@@ -20,6 +21,10 @@
 using namespace std;
 //---------------------------------------------------------------------------
 
+//--------------------------------------------------------------------------
+user_mode Ask_Callback(user_mode* Mode, const string& FileName, bool Always);
+
+//--------------------------------------------------------------------------
 class global
 {
 public:
@@ -45,6 +50,7 @@ public:
     size_t                      Path_Pos_Global;
     vector<string>              Inputs;
     license                     License;
+    user_mode                        Mode = Ask;
     errors                      Errors;
 
     // Options

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -142,7 +142,11 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
 
     // Output
     for (map<string, string>::iterator Option = Global.OutputOptions.begin(); Option != Global.OutputOptions.end(); Option++)
-        Command += " -" + Option->first + ' ' + Option->second;
+    {
+        Command += " -" + Option->first;
+        if (!Option->second.empty())
+            Command += ' ' + Option->second;
+    }
     for (size_t i = 0; i < Attachments.size(); i++)
     {
         // Info
@@ -193,19 +197,13 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
         cout << Command;
     else
     {
-        if (int Value = system(Command.c_str()))
-        {
-            #if !(defined(_WIN32) || defined(_WINDOWS))
-                if (Value > 0xFF && !(Value & 0xFF))
-                   Value++; // On Unix-like systems, exit status code is sometimes casted to 8-bit long, and system() returns a value multiple of 0x100 when e.g. the command does not exist. We increment the value by 1 in order to have cast to 8-bit not 0 (which can be considered as "OK" by some commands e.g. appending " && echo OK")
-            #endif
-            return Value;
-        }
+        int Value = system(Command.c_str());
+        #if !(defined(_WIN32) || defined(_WINDOWS))
+        if (Value > 0xFF && !(Value & 0xFF))
+                Value++; // On Unix-like systems, exit status code is sometimes casted to 8-bit long, and system() returns a value multiple of 0x100 when e.g. the command does not exist. We increment the value by 1 in order to have cast to 8-bit not 0 (which can be considered as "OK" by some commands e.g. appending " && echo OK")
+        #endif
 
-        // Delete the temporary file
-        int Result = remove(Global.rawcooked_reversibility_data_FileName.c_str());
-        if (Result)
-            cerr << "Error: can not remove temporary file " << Global.rawcooked_reversibility_data_FileName << endl;
+        return Value;
     }
 
     return 0;

--- a/Source/Lib/BitStream/BitStream.h
+++ b/Source/Lib/BitStream/BitStream.h
@@ -30,7 +30,7 @@ public:
     }
     BitStream(const uint8_t* Buffer_, size_t Size_) {
         Buffer = Buffer_;
-        Buffer_Size = Buffer_Size_Init = Size_ * 8; //Size is in bits
+        Buffer_Size = Buffer_Size_Init = Size_ * 8; //SizeOnDisk is in bits
         BufferUnderRun = false;
     }
     ~BitStream() {}
@@ -38,7 +38,7 @@ public:
     void Attach(const uint8_t* Buffer_, size_t Size_)
     {
         Buffer = Buffer_;
-        Buffer_Size = Buffer_Size_Init = Size_ * 8; //Size is in bits
+        Buffer_Size = Buffer_Size_Init = Size_ * 8; //SizeOnDisk is in bits
         BufferUnderRun = false;
     }
 

--- a/Source/Lib/Config.h
+++ b/Source/Lib/Config.h
@@ -20,6 +20,17 @@ using namespace std;
 typedef int32_t pixel_t;
 
 //---------------------------------------------------------------------------
+// Defines the mode of user interaction
+
+enum user_mode
+{
+    Ask,
+    AlwaysNo,
+    AlwaysYes,
+};
+typedef user_mode(*ask_callback)(user_mode* Mode, const string& FileName, const string& ExtraText, bool Always);
+
+//---------------------------------------------------------------------------
 // Platform specific
 #if defined(_WIN32) || defined(_WINDOWS)
     static const char PathSeparator = '\\';

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -16,7 +16,9 @@ namespace tiff_issue { extern const char** ErrorTexts[]; }
 namespace wav_issue { extern const char** ErrorTexts[]; }
 namespace aiff_issue { extern const char** ErrorTexts[]; }
 namespace matroska_issue { extern const char** ErrorTexts[]; }
-namespace file_issue { extern const char** ErrorTexts[]; }
+namespace intermediatewrite_issue { extern const char** ErrorTexts[]; }
+namespace filewriter_issue { extern const char** ErrorTexts[]; }
+namespace filechecker_issue { extern const char** ErrorTexts[]; }
 static const char*** AllErrorTexts[] =
 {
     dpx_issue::ErrorTexts,
@@ -25,8 +27,11 @@ static const char*** AllErrorTexts[] =
     aiff_issue::ErrorTexts,
     matroska_issue::ErrorTexts,
     NULL,
+    intermediatewrite_issue::ErrorTexts,
+    filewriter_issue::ErrorTexts,
+    filechecker_issue::ErrorTexts,
 };
-static_assert(Parser_Max == sizeof(AllErrorTexts) / sizeof(const char***), IncoherencyMessage); \
+static_assert(IO_Max == sizeof(AllErrorTexts) / sizeof(const char***), IncoherencyMessage); \
 
 
 //---------------------------------------------------------------------------
@@ -63,7 +68,7 @@ const char* errors::ErrorMessage()
     if (Parsers.empty())
         return NULL;
 
-    ErrorMessageCache.clear();
+    ErrorMessageCache = '\n';
 
     bitset<error::Type_Max> HasErrors;
 
@@ -94,12 +99,12 @@ const char* errors::ErrorMessage()
                         ErrorMessageCache += '\n';
                     }
                 }
-                else if (i == Parser_FileWriter)
+                else if (i < IO_Max)
                 {
                     if (Parsers[i].Codes[j][k].StringList)
                     {
                         ErrorMessageCache += "Error: ";
-                        ErrorMessageCache += file_issue::ErrorTexts[j][k];
+                        ErrorMessageCache += AllErrorTexts[i][j][k];
                         ErrorMessageCache += '.';
                         ErrorMessageCache += '\n';
                         std::vector<string>& List = *Parsers[i].Codes[j][k].StringList;

--- a/Source/Lib/Errors.h
+++ b/Source/Lib/Errors.h
@@ -31,7 +31,10 @@ enum parser
     Parser_Matroska,
     Parser_License,
     Parser_Max, // After this line, parsers are not really parsers and must be specifically handled
-    Parser_FileWriter,
+    IO_IntermediateWriter = Parser_Max,
+    IO_FileWriter,
+    IO_FileChecker,
+    IO_Max,
 };
 
 namespace error

--- a/Source/Lib/License.cpp
+++ b/Source/Lib/License.cpp
@@ -151,7 +151,7 @@ void license_input::BufferOverflow()
 //---------------------------------------------------------------------------
 bool DecodeLicense(const string& FromUser, license_internal* License)
 {
-    // Size
+    // SizeOnDisk
     if (FromUser.size()>200)
     {
         cerr << "Invalid size of license key." << endl;

--- a/Source/Lib/RAWcooked/RAWcooked.h
+++ b/Source/Lib/RAWcooked/RAWcooked.h
@@ -38,20 +38,22 @@ public:
     void                        Parse();
     void                        ResetTrack();
     void                        Close();
+    void                        Delete();
 
     string                      FileName;
     string                      OutputFileName;
     uint64_t                    FileSize;
 
     // Errors
+    user_mode*                  Mode = NULL;
+    ask_callback                Ask_Callback = NULL;
     errors*                     Errors = NULL;
 
 private:
-    uint64_t                    Buffer_Offset;
-
     // File IO
     file                        File;
     size_t                      BlockCount;
+    bool                        File_WasCreated = false;
     void WriteToDisk(uint8_t* Buffer, size_t Buffer_Size);
 
     // First frame info


### PR DESCRIPTION
Check file instead of writing it if it already exists and write it only if not same, avoiding useless file writes.
Do not modify a file without explicit user permission, fix https://github.com/MediaArea/RAWcooked/issues/122.
Improve speed of WAV writing by avoiding to open/close the output file at each Matroska packet analyzed.
Better handling and error info about I/O issues (no read or write access to the files, cannot create directories etc)
Delete intermediate file in all cases (except if external encoding is requested).