### PR TITLE
Conformance check feature

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -75,14 +75,14 @@ int global::SetCheck(const char* Value, int& i)
 {
     if (Value && (strcmp(Value, "0") == 0 || strcmp(Value, "partial") == 0))
     {
-        CheckPadding = false;
+        Actions.reset(Action_CheckPadding);
         ++i; // Next argument is used
         cerr << "Warning: \" --check " << Value << "\" is deprecated, use \" --no-check-padding\" instead.\n" << endl;
         return 0;
     }
     if (Value && (strcmp(Value, "1") == 0 || strcmp(Value, "full") == 0))
     {
-        CheckPadding = true;
+        Actions.set(Action_CheckPadding);
         ++i; // Next argument is used
         cerr << "Warning: \" --check " << Value << "\" is deprecated, use \" --check-padding\" instead.\n" << endl;
         return 0;
@@ -95,7 +95,21 @@ int global::SetCheck(const char* Value, int& i)
 //---------------------------------------------------------------------------
 int global::SetCheckPadding(bool Value)
 {
-    CheckPadding = true;
+    Actions.set(Action_CheckPadding, Value);
+    return 0;
+}
+
+//---------------------------------------------------------------------------
+int global::SetConch(bool Value)
+{
+    Actions.set(Action_Conch, Value);
+    return 0;
+}
+
+//---------------------------------------------------------------------------
+int global::SetEncode(bool Value)
+{
+    Actions.set(Action_Encode, Value);
     return 0;
 }
 
@@ -304,10 +318,10 @@ int global::ManageCommandLine(const char* argv[], int argc)
     StoreLicenseKey = false;
     DisplayCommand = false;
     AcceptFiles = false;
-    CheckPadding = false;
     OutputFileName_IsProvided = false;
     Quiet = false;
     Check = false;
+    Actions.set(Action_Encode);
     ProgressIndicator_Thread = NULL;
 
     for (int i = 1; i < argc; i++)
@@ -368,12 +382,24 @@ int global::ManageCommandLine(const char* argv[], int argc)
             if (Value)
                 return Value;
         }
+        else if (strcmp(argv[i], "--conch") == 0)
+        {
+            int Value = SetConch(true);
+            if (Value)
+                return Value;
+        }
         else if ((strcmp(argv[i], "--display-command") == 0 || strcmp(argv[i], "-d") == 0))
         {
             int Value = SetDisplayCommand();
             if (Value)
                 return Value;
             License.Feature(Feature_GeneralOptions);
+        }
+        else if (strcmp(argv[i], "--encode") == 0)
+        {
+            int Value = SetEncode(true);
+            if (Value)
+                return Value;
         }
         else if (strcmp(argv[i], "--file") == 0)
         {
@@ -398,13 +424,24 @@ int global::ManageCommandLine(const char* argv[], int argc)
         else if (strcmp(argv[i], "--no-check") == 0)
         {
             int Value = SetCheck(false);
-            License.Feature(Feature_GeneralOptions);
             if (Value)
                 return Value;
         }
         else if (strcmp(argv[i], "--no-check-padding") == 0)
         {
             int Value = SetCheckPadding(false);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--no-conch") == 0)
+        {
+            int Value = SetConch(false);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--no-encode") == 0)
+        {
+            int Value = SetEncode(false);
             if (Value)
                 return Value;
         }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <condition_variable>
 #include <thread>
+#include <bitset>
 using namespace std;
 //---------------------------------------------------------------------------
 
@@ -41,12 +42,12 @@ public:
     bool                        StoreLicenseKey;
     bool                        DisplayCommand;
     bool                        AcceptFiles;
-    bool                        CheckPadding;
     bool                        HasAtLeastOneDir;
     bool                        HasAtLeastOneFile;
     bool                        OutputFileName_IsProvided;
     bool                        Quiet;
     bool                        Check;
+    bitset<Action_Max>          Actions;
 
     // Intermediate info
     size_t                      Path_Pos_Global;
@@ -77,6 +78,8 @@ private:
     int SetCheck(bool Value);
     int SetCheck(const char* Value, int& i);
     int SetCheckPadding(bool Value);
+    int SetConch(bool Value);
+    int SetEncode(bool Value);
 
     // Progress indicator
     condition_variable          ProgressIndicator_IsEnd;

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -92,6 +92,12 @@ ReturnValue Help(const char* Name)
     cout << "              It is quicker but may lead to partial reversibility with" << endl;
     cout << "              non conform files." << endl;
     cout << "              Is default (it may change in the future)" << endl;
+    cout << "       --conch" << endl;
+    cout << "              Conformance check of the format, when supported." << endl;
+    cout << "              Currently partially implemented for DPX." << endl;
+    cout << "       --no-conch" << endl;
+    cout << "              Don't do conformance check (see above)." << endl;
+    cout << "              Is default (it may change in the future)" << endl;
     cout << endl;
     cout << "       --display-command | -d" << endl;
     cout << "              When an external encoder/decoder is used, display the command to" << endl;

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -86,7 +86,7 @@ bool parse_info::ParseFile_Input(input_base& SingleFile)
 {
     // Init
     SingleFile.AcceptTruncated = false;
-    SingleFile.CheckPadding = Global.CheckPadding;
+    SingleFile.Actions = Global.Actions;
 
     // Parse
     SingleFile.Parse(FileMap);
@@ -344,7 +344,7 @@ int main(int argc, const char* argv[])
     Global.ProgressIndicator_Stop();
 
     // FFmpeg
-    if (!Value)
+    if (!Value && Global.Actions[Action_Encode])
         Value = Output.Process(Global);
 
     // RAWcooked file

--- a/Source/Lib/AIFF/AIFF.cpp
+++ b/Source/Lib/AIFF/AIFF.cpp
@@ -65,6 +65,7 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     unsupported::MessageText,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -27,6 +27,7 @@ class dpx : public input_base_uncompressed
 {
 public:
     dpx(errors* Errors = nullptr);
+    ~dpx();
 
     string                      Flavor_String();
 
@@ -108,8 +109,14 @@ public:
 private:
     void                        ParseBuffer();
     void                        BufferOverflow();
+    void                        ConformanceCheck();
     void                        Undecodable(dpx_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
     void                        Unsupported(dpx_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
+    void                        Invalid(dpx_issue::invalid::code Code) { input_base::Invalid((error::invalid::code)Code); }
+
+    // Comparison
+    uint8_t*                    HeaderCopy = NULL;
+    uint64_t                    HeaderCopy_Info; // 0-11: buffer size - 1, 12: ignore offsets to data image 
 };
 
 string DPX_Flavor_String(uint8_t Flavor);

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -51,6 +51,7 @@ static const char* ErrorTypes_Strings[] =
 {
     "Error: undecodable",
     "Error: unsupported",
+    "Conformance issue:",
 };
 static_assert(error::Type_Max == sizeof(ErrorTypes_Strings) / sizeof(const char*), IncoherencyMessage); \
 
@@ -59,6 +60,7 @@ static const char* ErrorTypes_Infos[] =
 {
     NULL,
     "Please contact info@mediaarea.net if you want support of such content",
+    "At least 1 file is not conform to specifications",
 };
 static_assert(error::Type_Max == sizeof(ErrorTypes_Infos) / sizeof(const char*), IncoherencyMessage); \
 

--- a/Source/Lib/Errors.h
+++ b/Source/Lib/Errors.h
@@ -43,6 +43,7 @@ namespace error
     {
         Undecodable,
         Unsupported,
+        Invalid,
         Type_Max
     };
 
@@ -56,6 +57,10 @@ namespace error
         enum code : uint8_t;
     }
     namespace unsupported
+    {
+        enum code : uint8_t;
+    }
+    namespace invalid
     {
         enum code : uint8_t;
     }

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -23,6 +23,8 @@ class filemap;
 enum action : uint8_t
 {
     Action_Encode,
+    Action_CheckPadding,
+    Action_Conch,
     Action_Max
 };
 
@@ -48,8 +50,7 @@ public:
 
     // Config
     bool                        AcceptTruncated = false;
-    bool                        CheckPadding = false;
-    bitset<Action_Max>          Actions = { 1 << Action_Encode };
+    bitset<Action_Max>          Actions;
 
     // Parse
     bool                        Parse(unsigned char* Buffer, size_t Buffer_Size);
@@ -88,7 +89,8 @@ protected:
 
     // Error message
     void                        Undecodable(error::undecodable::code Code) { Error(error::Undecodable, (error::generic::code)Code); }
-    void                        Unsupported(error::unsupported::code Code) { Error(error::Unsupported, (error::generic::code)Code); }
+    void                        Unsupported(error::unsupported::code Code) { if (!Actions[Action_Encode]) return;  Error(error::Unsupported, (error::generic::code)Code); }
+    void                        Invalid(error::invalid::code Code) { Error(error::Invalid, (error::generic::code)Code); }
 
     // Info
     void                        ClearInfo() { Info.reset(); }

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -70,6 +70,7 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
@@ -101,6 +102,7 @@ namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const 
 const char** ErrorTexts[] =
 {
     undecodable::MessageText,
+    nullptr,
     nullptr,
 };
 
@@ -544,6 +546,7 @@ namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const 
 const char** ErrorTexts[] =
 {
     undecodable::MessageText,
+    nullptr,
     nullptr,
 };
 

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -46,6 +46,7 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/TIFF/TIFF.cpp
+++ b/Source/Lib/TIFF/TIFF.cpp
@@ -106,6 +106,7 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     unsupported::MessageText,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/WAV/WAV.cpp
+++ b/Source/Lib/WAV/WAV.cpp
@@ -81,6 +81,7 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     unsupported::MessageText,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);


### PR DESCRIPTION
Proof of concept, not all conformance checks are implemented yet (and a part of them may be never implemented if no interest by sponsors).

`rawcooked bla --conch` does conformance check in addition to classic encode.
`rawcooked bla --no-encode --conch` does conformance check only.

In addition to already existing integrity checks for being sure we can safely encode the stream, the following tests are done on [synthetic files](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/tree/master/Formats/DPX/Conformance):

```
Conformance issue: DPX Offset to image data in bytes.
Conformance issue: DPX Total image file size.
Conformance issue: DPX Ditto key.
Conformance issue: DPX Ditto key is set to "same as the previous frame" but header data differs.
At least 1 file is not conform to specifications.
```

ToDo: merge already existing integrity checks (the ones preventing encoding) and new conformance checks (which do not prevent encoding) in an unique report.