### PR TITLE
Detect and reject DPX streams with a gap in number sequence

### DIFF
--- a/Source/CLI/Input.h
+++ b/Source/CLI/Input.h
@@ -24,7 +24,7 @@ public:
 
     // Commands
     int AnalyzeInputs(global& Global);
-    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber);
+    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, errors* Errors = nullptr);
 };
 
 #endif

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -134,7 +134,7 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
     // Management
     Flavor = SingleFile.Flavor_String();
     if (SingleFile.IsSequence)
-        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber);
+        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber, &Global.Errors);
     if (RemovedFiles.empty())
         RemovedFiles.push_back(*Name);
     else

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -19,6 +19,7 @@ namespace matroska_issue { extern const char** ErrorTexts[]; }
 namespace intermediatewrite_issue { extern const char** ErrorTexts[]; }
 namespace filewriter_issue { extern const char** ErrorTexts[]; }
 namespace filechecker_issue { extern const char** ErrorTexts[]; }
+namespace fileinput_issue { extern const char** ErrorTexts[]; }
 namespace hashes_issue { extern const char** ErrorTexts[]; }
 static const char*** AllErrorTexts[] =
 {
@@ -33,6 +34,7 @@ static const char*** AllErrorTexts[] =
     intermediatewrite_issue::ErrorTexts,
     filewriter_issue::ErrorTexts,
     filechecker_issue::ErrorTexts,
+    fileinput_issue::ErrorTexts,
     hashes_issue::ErrorTexts,
 };
 static_assert(IO_Max == sizeof(AllErrorTexts) / sizeof(const char***), IncoherencyMessage); \

--- a/Source/Lib/Errors.h
+++ b/Source/Lib/Errors.h
@@ -36,6 +36,7 @@ enum parser
     IO_IntermediateWriter = Parser_Max,
     IO_FileWriter,
     IO_FileChecker,
+    IO_FileInput,
     IO_Hashes,
     IO_Max,
 };


### PR DESCRIPTION
DPX stream with a gap in the file naming sequence is now rejected instead of creating 2 streams in the resulting MKV (I guess there is no real usage of a gap in a file naming sequence for 2 streams...)

With [these sample packages](https://github.com/MediaArea/RAWcooked-RegressionTestingFiles/tree/master/BuggyPackages/MissingImageInSequence):

```
Error: Isn't a file missing? Unsupported gap in file names.
       MissingPenultimateFrame\000009.dpx
```

```
Error: Isn't a file missing? Unsupported gap in file names.
       MissingImageInSequence\MissingAllBut2Frames\009002.dpx
       MissingImageInSequence\MissingAllBut2Frames\900009.dpx
```
