### PR TITLE
 Add " --all" and " --none" options

### DIFF
--- a/Project/GNU/CLI/test/test1b.sh
+++ b/Project/GNU/CLI/test/test1b.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# same as test1 except ' --check full -slices 4' option
+# same as test1 except ' --check-padding -slices 4' option
 
 PATH="${PWD}:$PATH"
 script_path="${PWD}/test"
@@ -27,7 +27,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        cmdline=$(${valgrind} rawcooked --file --check full -slices 4 -d "${file}" 2>${script_path}/stderr)
+        cmdline=$(${valgrind} rawcooked --file --check-padding -slices 4 -d "${file}" 2>${script_path}/stderr)
         result=$?
         stderr="$(<${script_path}/stderr)"
         rm -f ${script_path}/stderr

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -121,6 +121,22 @@ int global::SetHash(bool Value)
 }
 
 //---------------------------------------------------------------------------
+int global::SetAll(bool Value)
+{
+    if (int ReturnValue = SetCheck(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetCheckPadding(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetConch(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetEncode(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetHash(Value))
+        return ReturnValue;
+    return 0;
+}
+
+//---------------------------------------------------------------------------
 int Error_NotTested(const char* Option1, const char* Option2 = NULL)
 {
     cerr << "Error: option " << Option1;
@@ -352,6 +368,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
                 return 1;
             }
         }
+        else if (strcmp(argv[i], "--all") == 0)
+        {
+            int Value = SetAll(true);
+            if (Value)
+                return Value;
+        }
         else if ((strcmp(argv[i], "--attachment-max-size") == 0 || strcmp(argv[i], "-s") == 0))
         {
             if (i + 1 == argc)
@@ -461,9 +483,15 @@ int global::ManageCommandLine(const char* argv[], int argc)
         }
         else if (strcmp(argv[i], "--no-hash") == 0)
         {
-        int Value = SetEncode(false);
-        if (Value)
-            return Value;
+            int Value = SetHash(false);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--none") == 0)
+        {
+            int Value = SetAll(false);
+            if (Value)
+                return Value;
         }
         else if (strcmp(argv[i], "--version") == 0)
         {

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -81,6 +81,7 @@ private:
     int SetConch(bool Value);
     int SetEncode(bool Value);
     int SetHash(bool Value);
+    int SetAll(bool Value);
 
     // Progress indicator
     thread*                     ProgressIndicator_Thread;

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -101,6 +101,12 @@ ReturnValue Help(const char* Name)
     cout << "              to all prompts and run non-interactively." << endl;
     cout << endl;
     cout << "ACTIONS" << endl;
+    cout << "       --all" << endl;
+    cout << "              Same as --check --check-padding --conch --encode --hash" << endl;
+    cout << "       --none" << endl;
+    cout << "              Same as --no-check --no-check-padding --no-conch --no-encode" << endl;
+    cout << "              --no-hash" << endl;
+    cout << endl;
     cout << "       --check" << endl;
     cout << "              Check that the encoded file can be correctly decoded." << endl;
     cout << "              If input is raw content, encode then decode input and check" << endl;

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -297,6 +297,8 @@ int ParseFile_Compressed(parse_info& ParseInfo)
         M.Quiet = Global.Quiet;
         M.NoWrite = Global.Check;
         M.NoOutputCheck = NoOutputCheck;
+        if (NoOutputCheck)
+            NoOutputCheck = M.Hashes_FromRAWcooked ? false : true; // If hashes are present in the file, output was check by using hashes
         if (ParseInfo.ParseFile_Input(M))
         {
             ReturnValue = 1;

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -113,14 +113,14 @@ const char* errors::ErrorMessage()
                 {
                     if (Parsers[i].Codes[j][k].StringList)
                     {
-                        ErrorMessageCache += j == error::Invalid? "Invalid: " : "Error: ";
+                        ErrorMessageCache += j == error::Invalid? "Conformance issue: " : "Error: ";
                         ErrorMessageCache += AllErrorTexts[i][j][k];
                         ErrorMessageCache += '.';
                         ErrorMessageCache += '\n';
                         std::vector<string>& List = *Parsers[i].Codes[j][k].StringList;
                         for (size_t l = 0; l < List.size(); l++)
                         {
-                            ErrorMessageCache += j == error::Invalid ? "         " : "       ";
+                            ErrorMessageCache += "       ";
                             ErrorMessageCache += List[l];
                             ErrorMessageCache += '\n';
                         }


### PR DESCRIPTION
shortcuts forcing all actions ` --all` or no actions ` --none`:
- check
- check-padding
- conch
- encode
- hash

then next options can override the status of actions.
Better to use them in scripts in case the default settings change in the future.

e.g. for doing only a conformance check (no encoding): `rawcooked --none --conch`

\+ some tiny bug fixes.