### PR TITLE
Check if WAV data size is a multiple of BlockAlign

### DIFF
--- a/Source/Lib/WAV/WAV.h
+++ b/Source/Lib/WAV/WAV.h
@@ -96,6 +96,9 @@ private:
     size_t Level;
     bool IsList;
 
+    // Temp
+    uint32_t                    BlockAlign = 0;
+
 #define WAV_ELEMENT(_NAME) \
         void _NAME(); \
         call SubElements_##_NAME(uint64_t Name);


### PR DESCRIPTION
Such data byte size is not expected with PCM (data byte size should be a multiple of BlockAlign in order to have only complete samples).