### PR TITLE
Split errors in errors and warnings

### DIFF
--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -128,6 +128,13 @@ ReturnValue Help(const char* Name)
     cout << "              non conform files." << endl;
     cout << "              Is default (it may change in the future)" << endl;
     cout << endl;
+    cout << "       --coherency" << endl;
+    cout << "              Coherency check of the package." << endl;
+    cout << "              Currently partially implemented." << endl;
+    cout << "              Is default (it may change in the future)" << endl;
+    cout << "       --no-coherency" << endl;
+    cout << "              Don't do coherency check (see above)." << endl;
+    cout << endl;
     cout << "       --conch" << endl;
     cout << "              Conformance check of the format, when supported." << endl;
     cout << "              Currently partially implemented for DPX." << endl;

--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -29,12 +29,12 @@
 
 namespace fileinput_issue {
 
-namespace unsupported
+namespace incoherent
 {
 
 static const char* MessageText[] =
 {
-    "Isn't a file missing? Unsupported gap in file names",
+    "file names (gap in file names)",
 };
 
 enum code : uint8_t
@@ -45,12 +45,13 @@ enum code : uint8_t
 
 namespace unsupported { static_assert(Max == sizeof(MessageText) / sizeof(const char*), IncoherencyMessage); }
 
-} // unsupported
+} // incoherent
 
 const char** ErrorTexts[] =
 {
     nullptr,
-    unsupported::MessageText,
+    nullptr,
+    incoherent::MessageText,
     nullptr,
 };
 
@@ -196,12 +197,12 @@ void input::DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<s
             {
                 if (Errors)
                 {
-                    Errors->Error(IO_FileInput, error::Unsupported, (error::generic::code)fileinput_issue::unsupported::FileMissing, Before.substr(Path_Pos) + FN + After);
+                    Errors->Error(IO_FileInput, error::Incoherent, (error::generic::code)fileinput_issue::incoherent::FileMissing, Before.substr(Path_Pos) + FN + After);
                     if (Number1 + 1 != Number2)
                     {
                         auto FN2 = to_string(Number2 - 1);
                         FN2.insert(0, FN.size() - FN2.size(), '0');
-                        Errors->Error(IO_FileInput, error::Unsupported, (error::generic::code)fileinput_issue::unsupported::FileMissing, Before.substr(Path_Pos) + FN2 + After);
+                        Errors->Error(IO_FileInput, error::Incoherent, (error::generic::code)fileinput_issue::incoherent::FileMissing, Before.substr(Path_Pos) + FN2 + After);
                     }
                 }
             }

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -391,6 +391,16 @@ int main(int argc, const char* argv[])
     // Progress indicator
     Global.ProgressIndicator_Stop();
 
+    if (!Value && Global.Errors.HasWarnings())
+    {
+        cerr << Global.Errors.ErrorMessage() << endl;
+        cerr << "Do you want to continue despite warnings ? [y/N] ";
+        string Result;
+        getline(cin, Result);
+        if (!(!Result.empty() && (Result[0] == 'Y' || Result[0] == 'y')))
+            Value = 1;
+    }
+
     // FFmpeg
     if (!Value && Global.Actions[Action_Encode])
         Value = Output.Process(Global);
@@ -425,7 +435,7 @@ int main(int argc, const char* argv[])
     }
 
     // Global errors
-    if (Global.Errors.ErrorMessage())
+    if (Global.Errors.HasErrors())
     {
         cerr << Global.Errors.ErrorMessage() << endl;
         if (!Value)

--- a/Source/Lib/AIFF/AIFF.cpp
+++ b/Source/Lib/AIFF/AIFF.cpp
@@ -66,6 +66,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     unsupported::MessageText,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -110,10 +110,11 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     unsupported::MessageText,
+    nullptr,
     invalid::MessageText,
 };
 
-//static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
+static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
 
 } // dpx_issue
 

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -59,15 +59,17 @@ static const char* ErrorTypes_Strings[] =
 {
     "Error: undecodable",
     "Error: unsupported",
-    "Conformance issue:",
+    "Warning: incoherent",
+    "Warning: non-conforming",
 };
 static_assert(error::Type_Max == sizeof(ErrorTypes_Strings) / sizeof(const char*), IncoherencyMessage); \
 
 //---------------------------------------------------------------------------
 static const char* ErrorTypes_Infos[] =
 {
-    NULL,
+    nullptr,
     "Please contact info@mediaarea.net if you want support of such content",
+    "Incoherency in characteristics of files is detected",
     "At least 1 file is not conform to specifications",
 };
 static_assert(error::Type_Max == sizeof(ErrorTypes_Infos) / sizeof(const char*), IncoherencyMessage); \
@@ -113,7 +115,8 @@ const char* errors::ErrorMessage()
                 {
                     if (Parsers[i].Codes[j][k].StringList)
                     {
-                        ErrorMessageCache += j == error::Invalid? "Conformance issue: " : "Error: ";
+                        ErrorMessageCache += ErrorTypes_Strings[j];
+                        ErrorMessageCache += ' ';
                         ErrorMessageCache += AllErrorTexts[i][j][k];
                         ErrorMessageCache += '.';
                         ErrorMessageCache += '\n';
@@ -148,8 +151,19 @@ void errors::Error(parser Parser, error::type Type, error::generic::code Code)
         Codes.resize(Code + 1);
 
     Codes[Code].Count++;
-    if ((Type == error::Undecodable || Type == error::Unsupported) && !HasErrors_Value)
-        HasErrors_Value = true;
+    switch (Type)
+    {
+        case error::Undecodable:
+        case error::Unsupported:
+            if (!HasErrors_Value)
+                HasErrors_Value = true;
+            break;
+        case error::Incoherent:
+        case error::Invalid:
+            if (!HasWarnings_Value)
+                HasWarnings_Value = true;
+            break;
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Errors.h
+++ b/Source/Lib/Errors.h
@@ -47,6 +47,7 @@ namespace error
     {
         Undecodable,
         Unsupported,
+        Incoherent,
         Invalid,
         Type_Max
     };
@@ -61,6 +62,10 @@ namespace error
         enum code : uint8_t;
     }
     namespace unsupported
+    {
+        enum code : uint8_t;
+    }
+    namespace incoherent
     {
         enum code : uint8_t;
     }
@@ -94,6 +99,7 @@ public:
     void                        Error(parser Parser, error::type Type, error::generic::code Code);
     void                        Error(parser Parser, error::type Type, error::generic::code Code, const string& String);
     bool                        HasErrors() { return HasErrors_Value; }
+    bool                        HasWarnings() { return HasWarnings_Value; }
     void                        ClearErrors() { Parsers.clear(); }
 
 private:
@@ -110,6 +116,7 @@ private:
     string                      ErrorMessageCache;
     void                        DeleteStrings();
     bool                        HasErrors_Value = false;
+    bool                        HasWarnings_Value = false;
 };
 
 #endif

--- a/Source/Lib/HashSum/HashSum.cpp
+++ b/Source/Lib/HashSum/HashSum.cpp
@@ -61,6 +61,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     nullptr,
     invalid::MessageText,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -77,6 +77,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     nullptr,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
@@ -108,6 +109,7 @@ namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const 
 const char** ErrorTexts[] =
 {
     undecodable::MessageText,
+    nullptr,
     nullptr,
     nullptr,
 };
@@ -619,6 +621,7 @@ namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const 
 const char** ErrorTexts[] =
 {
     undecodable::MessageText,
+    nullptr,
     nullptr,
     nullptr,
 };

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -47,6 +47,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     nullptr,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/TIFF/TIFF.cpp
+++ b/Source/Lib/TIFF/TIFF.cpp
@@ -107,6 +107,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     unsupported::MessageText,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);

--- a/Source/Lib/WAV/WAV.cpp
+++ b/Source/Lib/WAV/WAV.cpp
@@ -82,6 +82,7 @@ const char** ErrorTexts[] =
     undecodable::MessageText,
     unsupported::MessageText,
     nullptr,
+    nullptr,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);


### PR DESCRIPTION
It should be a bit more coherent after all the new additions from previous PRs (and the next one about A/V sync test).

I split messages in 2x2 groups:
- "Error: undecodable [...]" --> Issue with input having too many problems, impossible to decode/encode due to input,
- "Error: unsupported [...]" --> input looks fine but RAWcooked does not yet support such input while guarantying the reversibility, RAWcooked issue,
- "Warning: incoherent [...]" --> There is chances that output will not be the expected one because we don't see a coherent content e.g. DPX sequence with "holes" in the numbering sequence, audio content not having the same duration as video content; RAWcooked can encode while guarantying the reversibility so we ask (can be overridden with " -y") the user if we should encode despite such coherency issues, it is set by default but test can be disabled with ` --no-coherency` (I didn't find a better name...),
- "Warning: non-conforming [...]" --> Content can be decoded / transcoded but is not conforming to specification, we ask  (can be overridden with " -y") the user if we should encode despite such conforming issues, it is not set by default (content has no big issues about playback) but can test can be enabled with ` --conch`  (or ` --all`)
