### PR TITLE
 Test of incoherent A/V sync 

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -100,6 +100,13 @@ int global::SetCheckPadding(bool Value)
 }
 
 //---------------------------------------------------------------------------
+int global::SetCoherency(bool Value)
+{
+    Actions.set(Action_Coherency, Value);
+    return 0;
+}
+
+//---------------------------------------------------------------------------
 int global::SetConch(bool Value)
 {
     Actions.set(Action_Conch, Value);
@@ -126,6 +133,8 @@ int global::SetAll(bool Value)
     if (int ReturnValue = SetCheck(Value))
         return ReturnValue;
     if (int ReturnValue = SetCheckPadding(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetCoherency(Value))
         return ReturnValue;
     if (int ReturnValue = SetConch(Value))
         return ReturnValue;
@@ -345,6 +354,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
     Quiet = false;
     Check = false;
     Actions.set(Action_Encode);
+    Actions.set(Action_Coherency);
     Hashes = hashes(&Errors);
     ProgressIndicator_Thread = NULL;
 
@@ -412,6 +422,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
             if (Value)
                 return Value;
         }
+        else if (strcmp(argv[i], "--coherency") == 0)
+        {
+            int Value = SetCoherency(true);
+            if (Value)
+                return Value;
+        }
         else if (strcmp(argv[i], "--conch") == 0)
         {
             int Value = SetConch(true);
@@ -468,6 +484,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
             int Value = SetCheckPadding(false);
             if (Value)
                 return Value;
+        }
+        else if (strcmp(argv[i], "--no-coherency") == 0)
+        {
+        int Value = SetCoherency(false);
+        if (Value)
+            return Value;
         }
         else if (strcmp(argv[i], "--no-conch") == 0)
         {

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -54,6 +54,10 @@ public:
     hashes                      Hashes;
     errors                      Errors;
 
+    // Conformance check intermediary info
+    vector<double>              Durations;
+    vector<string>              Durations_FileName;
+
     // Options
     int ManageCommandLine(const char* argv[], int argc);
     int SetDefaults();

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -78,6 +78,7 @@ private:
     int SetCheck(bool Value);
     int SetCheck(const char* Value, int& i);
     int SetCheckPadding(bool Value);
+    int SetCoherency(bool Value);
     int SetConch(bool Value);
     int SetEncode(bool Value);
     int SetHash(bool Value);

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -102,10 +102,11 @@ ReturnValue Help(const char* Name)
     cout << endl;
     cout << "ACTIONS" << endl;
     cout << "       --all" << endl;
-    cout << "              Same as --check --check-padding --conch --encode --hash" << endl;
+    cout << "              Same as --check --check-padding --coherency --conch --encode" << endl;
+    cout << "              --hash" << endl;
     cout << "       --none" << endl;
-    cout << "              Same as --no-check --no-check-padding --no-conch --no-encode" << endl;
-    cout << "              --no-hash" << endl;
+    cout << "              Same as --no-check --no-check-padding --no coherency --no-conch" << endl;
+    cout << "              --no-encode --no-hash" << endl;
     cout << endl;
     cout << "       --check" << endl;
     cout << "              Check that the encoded file can be correctly decoded." << endl;

--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------
 #include "CLI/Input.h"
 #include "Lib/Config.h"
+#include "Lib/Input_Base.h"
 #include <iostream>
 #if defined(_WIN32) || defined(_WINDOWS)
     #include "windows.h"
@@ -95,7 +96,7 @@ void DetectPathPos(const string &Name, size_t& Path_Pos)
 }
 
 //---------------------------------------------------------------------------
-void input::DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, errors* Errors)
+void input::DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, bitset<Action_Max> const& Actions, errors* Errors)
 {
     string FN(Files[AllFiles_Pos]);
     string Path;
@@ -183,7 +184,7 @@ void input::DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<s
     }
 
     // Coherency test
-    if (!CheckIfFilesExist && AllFiles_Pos && AllFiles_Pos < Files.size())
+    if (!CheckIfFilesExist && AllFiles_Pos && AllFiles_Pos < Files.size() && Actions[Action_Coherency])
     {
         auto& File1 = Files[AllFiles_Pos - 1];
         auto& File2 = Files[AllFiles_Pos];

--- a/Source/CLI/Input.h
+++ b/Source/CLI/Input.h
@@ -24,7 +24,7 @@ public:
 
     // Commands
     int AnalyzeInputs(global& Global);
-    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, errors* Errors = nullptr);
+    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, bitset<Action_Max> const& Actions, errors* Errors = nullptr);
 };
 
 #endif

--- a/Source/CLI/Input.h
+++ b/Source/CLI/Input.h
@@ -25,6 +25,9 @@ public:
     // Commands
     int AnalyzeInputs(global& Global);
     void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, bitset<Action_Max> const& Actions, errors* Errors = nullptr);
+
+    // Checks
+    static void CheckDurations(vector<double> const& Durations, vector<string> const& Durations_FileName, errors* Errors = nullptr);
 };
 
 #endif

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -134,7 +134,7 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
     // Management
     Flavor = SingleFile.Flavor_String();
     if (SingleFile.IsSequence)
-        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber, &Global.Errors);
+        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber, Global.Actions, &Global.Errors);
     if (RemovedFiles.empty())
         RemovedFiles.push_back(*Name);
     else

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -171,8 +171,7 @@ const size_t DPX_Tested_Size = sizeof(DPX_Tested) / sizeof(dpx_tested);
 
 //---------------------------------------------------------------------------
 dpx::dpx(errors* Errors_Source) :
-    input_base_uncompressed(Errors_Source, Parser_DPX, true),
-    FrameRate(nullptr)
+    input_base_uncompressed(Errors_Source, Parser_DPX, true)
 {
 }
 
@@ -266,7 +265,7 @@ void dpx::ParseBuffer()
     if (Get_X4() != 0)
         Unsupported(unsupported::EolPadding);
    
-    if (IndustryHeaderSize && FrameRate)
+    if (IndustryHeaderSize && InputInfo)
     {
         Buffer_Offset = 1724;
         double FrameRate_Film = Get_XF4(); // Frame rate of original (frames/s) 
@@ -282,14 +281,7 @@ void dpx::ParseBuffer()
         //if (!FrameRate_Film && !FrameRate_Television)
         //    Unsupported(unsupported::FrameRate_Unavailable);
 
-        double FrameRateD = FrameRate_Film ? FrameRate_Film : FrameRate_Television;
-        if (FrameRateD)
-        {
-            stringstream ss;
-            ss.precision(11);
-            ss << FrameRateD;
-            *FrameRate = ss.str();
-        }
+        InputInfo->FrameRate = FrameRate_Film ? FrameRate_Film : FrameRate_Television;
     }
 
     // Supported?

--- a/Source/Lib/DPX/DPX.h
+++ b/Source/Lib/DPX/DPX.h
@@ -36,7 +36,6 @@ public:
     // Info
     size_t                      slice_x;
     size_t                      slice_y;
-    string*                     FrameRate;
 
     enum flavor : uint8_t
     {

--- a/Source/Lib/Errors.cpp
+++ b/Source/Lib/Errors.cpp
@@ -190,6 +190,20 @@ void errors::Error(parser Parser, error::type Type, error::generic::code Code, c
     List.push_back(String);
     if ((Type == error::Undecodable || Type == error::Unsupported) && !HasErrors_Value)
         HasErrors_Value = true;
+
+    switch (Type)
+    {
+        case error::Undecodable:
+        case error::Unsupported:
+            if (!HasErrors_Value)
+                HasErrors_Value = true;
+            break;
+        case error::Incoherent:
+        case error::Invalid:
+            if (!HasWarnings_Value)
+                HasWarnings_Value = true;
+            break;
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -25,6 +25,7 @@ enum action : uint8_t
 {
     Action_Encode,
     Action_Hash,
+    Action_Coherency,
     Action_Conch,
     Action_CheckPadding,
     Action_AcceptTruncated,

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -44,6 +44,15 @@ enum info : uint8_t
 typedef uint8_t flavor;
 
 //---------------------------------------------------------------------------
+struct input_info
+{
+    double                      FrameRate = 0;
+    size_t                      FrameCount = 0;
+    double                      SampleRate = 0;
+    size_t                      SampleCount = 0;
+};
+
+//---------------------------------------------------------------------------
 class input_base
 {
 public:
@@ -65,6 +74,7 @@ public:
     bool                        IsDetected() { return Info[Info_IsDetected]; }
     bool                        IsSupported() { return Info[Info_IsSupported]; }
     bool                        HasErrors() { return Info[Info_HasErrors]; }
+    input_info*                 InputInfo = nullptr;
 
     // Common info
     parser                      ParserCode;
@@ -72,7 +82,6 @@ public:
 protected:
     virtual void                ParseBuffer() = 0;
     virtual void                BufferOverflow() = 0;
-
     filemap*                    FileMap;
     unsigned char*              Buffer;
     size_t                      Buffer_Size;

--- a/Source/Lib/TIFF/TIFF.cpp
+++ b/Source/Lib/TIFF/TIFF.cpp
@@ -161,8 +161,7 @@ struct tiff_tested TIFF_Tested[] =
 
 //---------------------------------------------------------------------------
 tiff::tiff(errors* Errors_Source) :
-    input_base_uncompressed(Errors_Source, Parser_TIFF, true),
-    FrameRate(NULL)
+    input_base_uncompressed(Errors_Source, Parser_TIFF, true)
 {
 }
 

--- a/Source/Lib/TIFF/TIFF.h
+++ b/Source/Lib/TIFF/TIFF.h
@@ -36,7 +36,6 @@ public:
     // Info
     size_t                      slice_x;
     size_t                      slice_y;
-    string*                     FrameRate;
 
     enum flavor : uint8_t
     {

--- a/Source/Lib/WAV/WAV.cpp
+++ b/Source/Lib/WAV/WAV.cpp
@@ -317,6 +317,9 @@ void wav::WAVE_data()
         uint64_t Size = Levels[Level].Offset_End - Buffer_Offset;
         if (Size % BlockAlign)
             Unsupported(unsupported::data_Size);
+
+        if (InputInfo && !InputInfo->SampleCount)
+            InputInfo->SampleCount = Size / BlockAlign;
     }
 
     // Can we compress?
@@ -446,6 +449,9 @@ void wav::WAVE_fmt_()
         return;
     }
     Flavor = WAV_Tested[Tested].Flavor;
+
+    if (InputInfo && !InputInfo->SampleRate)
+        InputInfo->SampleRate = SamplesPerSec;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
If there are 2+ streams e.g. video and audio content, we expect that they have the same duration, else we ask if this is wanted.
Arbitrary choice of an accepted difference of 1 second, a future patch will permit to tweak the value.

Example of result:
```
Warning: incoherent A/V sync (durations are different).
       818_DCDM_P3_IA_FIC_000918/audio/818_DCP_5point1_20170221.500ms.wav (0.500000s)
       818_DCDM_P3_IA_FIC_000918/818_OV_FR_ST/818_OV_FR_ST_0086956.dpx (6.500000s)

Do you want to continue despite warnings ? [y/N]
```

PR contains a commit updating https://github.com/MediaArea/RAWcooked/pull/212.