### PR TITLE
Enable file truncation on non Windows platforms

### DIFF
--- a/Source/Lib/FileIO.cpp
+++ b/Source/Lib/FileIO.cpp
@@ -5,6 +5,7 @@
  */
 
 //---------------------------------------------------------------------------
+#define _GNU_SOURCE // Needed for ftruncate on GNU compiler
 #include "Lib/FileIO.h"
 #include <iostream>
 #include <sstream>
@@ -22,13 +23,6 @@
     #include <unistd.h>
     #include <sys/stat.h>
     #include <sys/mman.h>
-    #ifndef ftruncate
-        int ftruncate(int __fd, off_t __length)
-        {
-            errno = ENOSYS;
-            return -1;
-        }
-    #endif
 #endif
 //---------------------------------------------------------------------------
 
@@ -339,7 +333,7 @@ file::return_value file::SetEndOfFile()
     {
         return Error_FileWrite;
     }
-    if (!ftruncate(P, length))
+    if (ftruncate(P, length))
     #endif
     {
         return Error_FileWrite;


### PR DESCRIPTION
Used when raw file on disk is bigger than the one stored in the compressed filed (and we don't erase the raw file on disk, we compare it and truncate it if this is enough to do).