### PR TITLE
Fix RAWcooked EBML sizes using value for "size is unknown" (0xFF, 0xFFFF...)

### DIFF
--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -19,7 +19,7 @@ int output::Process(global& Global)
     {
         cerr << "Error: no A/V content detected.\nPlease contact info@mediaarea.net if you want support of such content." << endl;
         return 1;
-    }
+    } 
 
     return 0;
 }

--- a/Source/Lib/AIFF/AIFF.cpp
+++ b/Source/Lib/AIFF/AIFF.cpp
@@ -381,12 +381,12 @@ void aiff::AIFF_SSND()
     if (IsSupported() && RAWcooked)
     {
         RAWcooked->Unique = true;
-        RAWcooked->Before = Buffer;
-        RAWcooked->Before_Size = Buffer_Offset + 8;
-        RAWcooked->After = Buffer + Levels[Level].Offset_End;
-        RAWcooked->After_Size = Buffer_Size - Levels[Level].Offset_End;
-        RAWcooked->In = nullptr;
-        RAWcooked->In_Size = 0;
+        RAWcooked->BeforeData = Buffer;
+        RAWcooked->BeforeData_Size = Buffer_Offset + 8;
+        RAWcooked->AfterData = Buffer + Levels[Level].Offset_End;
+        RAWcooked->AfterData_Size = Buffer_Size - Levels[Level].Offset_End;
+        RAWcooked->InData = nullptr;
+        RAWcooked->InData_Size = 0;
         RAWcooked->FileSize = (uint64_t)-1;
         if (Actions[Action_Hash])
         {

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -382,12 +382,12 @@ void dpx::ParseBuffer()
     if (IsSupported() && RAWcooked)
     {
         RAWcooked->Unique = false;
-        RAWcooked->Before = Buffer;
-        RAWcooked->Before_Size = OffsetToData;
-        RAWcooked->After = Buffer + OffsetAfterData;
-        RAWcooked->After_Size = Buffer_Size - OffsetAfterData;
-        RAWcooked->In = In;
-        RAWcooked->In_Size = In_Size;
+        RAWcooked->BeforeData = Buffer;
+        RAWcooked->BeforeData_Size = OffsetToData;
+        RAWcooked->AfterData = Buffer + OffsetAfterData;
+        RAWcooked->AfterData_Size = Buffer_Size - OffsetAfterData;
+        RAWcooked->InData = In;
+        RAWcooked->InData_Size = In_Size;
         RAWcooked->FileSize = (uint64_t)-1;
         if (Actions[Action_Hash])
         {

--- a/Source/Lib/Input_Base.cpp
+++ b/Source/Lib/Input_Base.cpp
@@ -212,6 +212,8 @@ uint64_t input_base::Get_EB()
     TEST_BUFFEROVERFLOW(1);
 
     uint64_t ToReturn = Buffer[Buffer_Offset];
+    if (!ToReturn)
+        return (uint64_t)-1; // Out of specifications, consider the value as Unlimited
     uint64_t s = 0;
     while (!(ToReturn&(((uint64_t)1) << (7 - s))))
         s++;

--- a/Source/Lib/Input_Base.cpp
+++ b/Source/Lib/Input_Base.cpp
@@ -262,12 +262,12 @@ void unknown::ParseBuffer()
     if (RAWcooked)
     {
         RAWcooked->Unique = true;
-        RAWcooked->Before = nullptr;
-        RAWcooked->Before_Size = 0;
-        RAWcooked->After = nullptr;
-        RAWcooked->After_Size = 0;
-        RAWcooked->In = nullptr;
-        RAWcooked->In_Size = 0;
+        RAWcooked->BeforeData = nullptr;
+        RAWcooked->BeforeData_Size = 0;
+        RAWcooked->AfterData = nullptr;
+        RAWcooked->AfterData_Size = 0;
+        RAWcooked->InData = nullptr;
+        RAWcooked->InData_Size = 0;
         RAWcooked->FileSize = (uint64_t)-1;
         if (Actions[Action_Hash])
         {

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -850,7 +850,10 @@ void matroska::ParseBuffer()
     {
         uint64_t Name = Get_EB();
         uint64_t Size = Get_EB();
-        Levels[Level].Offset_End = Buffer_Offset + Size;
+        if (Size <= Levels[Level - 1].Offset_End - Buffer_Offset)
+            Levels[Level].Offset_End = Buffer_Offset + Size;
+        else
+            Levels[Level].Offset_End = Levels[Level - 1].Offset_End;
         call Call = (this->*Levels[Level - 1].SubElements)(Name);
         IsList = false;
         (this->*Call)();

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -114,6 +114,8 @@ static size_t Size_EB(uint64_t Value)
     size_t S_l = 1;
     while (Value >> (S_l * 7))
         S_l++;
+    if (Value == (uint64_t)-1 >> ((sizeof(Value) - S_l) * 8 + S_l))
+        S_l++;
     return S_l;
 }
 

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -545,6 +545,7 @@ void rawcooked::ResetTrack()
 //---------------------------------------------------------------------------
 void rawcooked::Close()
 {
+    File.SetEndOfFile();
     File.Close();
 }
 

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -8,6 +8,7 @@
 #include "Lib/RAWcooked/RAWcooked.h"
 #include "Lib/Config.h"
 #include "zlib.h"
+#include <algorithm>
 #include <cstring>
 using namespace std;
 
@@ -108,97 +109,196 @@ enum hashformat
 };
 
 //---------------------------------------------------------------------------
-static size_t Size_EB(uint32_t Name, uint64_t Size)
-{
-    size_t N_l = 1;
-    while (Name >> (N_l * 7))
-        N_l++;
-
-    size_t S_l = 1;
-    while (Size >> (S_l * 7))
-        S_l++;
-
-    return N_l + S_l + Size;
-}
-
-//---------------------------------------------------------------------------
-static size_t Size_EB(uint64_t Size)
+static size_t Size_EB(uint64_t Value)
 {
     size_t S_l = 1;
-    while (Size >> (S_l * 7))
+    while (Value >> (S_l * 7))
         S_l++;
     return S_l;
 }
 
 //---------------------------------------------------------------------------
-static size_t Size_Number(uint64_t Number)
+static size_t Size_Number(uint64_t Value)
 {
     size_t S_l = 1;
-    while (Number >> (S_l * 8))
+    while (Value >> (S_l * 8))
         S_l++;
     return S_l;
 }
 
 //---------------------------------------------------------------------------
-static void Put_EB(unsigned char* Buffer, size_t& Offset, uint32_t Name, uint64_t Size)
+class ebml_writer
 {
-    size_t N_l = 1;
-    while (Name >> (N_l * 7))
-        N_l++;
-    uint32_t N2 = Name | (((uint32_t)1) << (N_l * 7));
-    while (N_l)
-    {
-        Buffer[Offset] = (uint8_t)(N2 >> ((N_l - 1)*8));
-        Offset++;
-        N_l--;
-    }
+public:
+    // Constructor / Destructor
+    ~ebml_writer();
 
-    size_t S_l = 1;
-    while (Size >> (S_l * 7))
-        S_l++;
-    uint64_t S2 = Size | (((uint64_t)1) << (S_l * 7));
-    while (S_l)
+    // Types
+    void EB(uint64_t Size);
+    void Block(uint32_t Name, uint64_t Size, const uint8_t* Data);
+    void String(uint32_t Name, const char* Data);
+    void Number(uint32_t Name, uint64_t Number);
+    void DataWithEncodedPrefix(uint32_t Name, uint64_t Prefix, uint64_t Size, const uint8_t* Data);
+    void CompressableData(uint32_t Name, const uint8_t* Data, uint64_t Size, uint64_t CompressedSize);
+
+    // Blocks
+    void Block_Begin(uint32_t Name);
+    void Block_End();
+    
+    // Buffer
+    void Set2ndPass();
+    uint8_t* GetBuffer();
+    size_t GetBufferSize();
+
+private:
+    std::vector<size_t> BlockSizes;
+    uint8_t* Buffer = NULL;
+    size_t Buffer_PreviousOffset = 0;
+    size_t Buffer_Offset = 0;
+};
+
+//---------------------------------------------------------------------------
+void ebml_writer::EB(uint64_t Size)
+{
+    size_t S_l = Size_EB(Size);
+
+    if (Buffer)
     {
-        Buffer[Offset] = (uint8_t)(S2 >> ((S_l - 1)*8));
-        Offset++;
-        S_l--;
+        uint64_t S2 = Size | (((uint64_t)1) << (S_l * 7));
+        while (S_l)
+        {
+            Buffer[Buffer_Offset] = (uint8_t)(S2 >> ((S_l - 1) * 8));
+            Buffer_Offset++;
+            S_l--;
+        }
+
+    }
+    else
+        Buffer_Offset += S_l;
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::Block(uint32_t Name, uint64_t Size, const uint8_t* Data)
+{
+    EB(Name);
+    EB(Size);
+
+    if (Buffer)
+    {
+        memcpy(Buffer + Buffer_Offset, Data, Size);
+    }
+    Buffer_Offset += Size;
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::String(uint32_t Name, const char* Data)
+{
+    Block(Name, strlen(Data), reinterpret_cast<const uint8_t*>(Data));
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::Number(uint32_t Name, uint64_t Number)
+{
+    EB(Name);
+    size_t S_l = Size_Number(Number);
+    EB(S_l);
+
+    if (Buffer)
+    {
+        while (S_l)
+        {
+            Buffer[Buffer_Offset] = (uint8_t)(Number >> ((S_l - 1) * 8));
+            Buffer_Offset++;
+            S_l--;
+        }
+    }
+    else
+        Buffer_Offset += S_l;
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::DataWithEncodedPrefix(uint32_t Name, uint64_t Prefix, uint64_t Size, const uint8_t* Data)
+{
+    EB(Name);
+    EB(Size_EB(Prefix) + Size);
+    EB(Prefix);
+
+    if (Buffer)
+    {
+        memcpy(Buffer + Buffer_Offset, Data, Size);
+    }
+    Buffer_Offset += Size;
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::CompressableData(uint32_t Name, const uint8_t* Data, uint64_t Size, uint64_t CompressedSize)
+{
+    if (!Size)
+        return;
+    if (CompressedSize)
+        DataWithEncodedPrefix(Name, Size, CompressedSize, Data);
+    else
+        DataWithEncodedPrefix(Name,     0,          Size, Data);
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::Block_Begin(uint32_t Name)
+{
+    EB(Name);
+    if (Buffer)
+    {
+        EB(BlockSizes.back());
+        BlockSizes.pop_back();
+    }
+    else
+        Buffer_PreviousOffset = Buffer_Offset;
+}
+
+//---------------------------------------------------------------------------
+void ebml_writer::Block_End()
+{
+    if (!Buffer)
+    {
+        BlockSizes.push_back(Buffer_Offset - Buffer_PreviousOffset);
+        EB(Buffer_Offset - Buffer_PreviousOffset);
     }
 }
 
 //---------------------------------------------------------------------------
-static void Put_EB(unsigned char* Buffer, size_t& Offset, uint64_t Size)
+void ebml_writer::Set2ndPass()
 {
-    size_t S_l = 1;
-    while (Size >> (S_l * 7))
-        S_l++;
-    uint64_t S2 = Size | (((uint64_t)1) << (S_l * 7));
-    while (S_l)
-    {
-        Buffer[Offset] = (uint8_t)(S2 >> ((S_l - 1) * 8));
-        Offset++;
-        S_l--;
-    }
+    if (Buffer)
+        return;
+
+    reverse(BlockSizes.begin(), BlockSizes.end()); // We'll decrement size for keeping track about where we are
+    Buffer = new uint8_t[Buffer_Offset];
+    Buffer_PreviousOffset = 0;
+    Buffer_Offset = 0;
 }
 
 //---------------------------------------------------------------------------
-static void Put_Number(unsigned char* Buffer, size_t& Offset, uint64_t Number)
+uint8_t* ebml_writer::GetBuffer()
 {
-    size_t S_l = 1;
-    while (Number >> (S_l * 8))
-        S_l++;
-    while (S_l)
-    {
-        Buffer[Offset] = (uint8_t)(Number >> ((S_l - 1) * 8));
-        Offset++;
-        S_l--;
-    }
+    return Buffer;
+}
+
+//---------------------------------------------------------------------------
+size_t ebml_writer::GetBufferSize()
+{
+    return Buffer_Offset;
+}
+
+//---------------------------------------------------------------------------
+ebml_writer::~ebml_writer()
+{
+    delete[] Buffer;
 }
 
 //---------------------------------------------------------------------------
 rawcooked::rawcooked() :
     Unique(false),
-    In(NULL),
-    In_Size(0),
+    InData(NULL),
+    InData_Size(0),
     FileSize((uint64_t)-1),
     BlockCount(0)
 {
@@ -224,12 +324,12 @@ void rawcooked::Parse()
     uint8_t* FileName = (uint8_t*)OutputFileName.c_str();
     size_t FileName_Size = OutputFileName.size();
     uint8_t* ToStore_FileName = FileName;
-    uint8_t* ToStore_Before = Before;
-    uint8_t* ToStore_After = After;
-    uint8_t* ToStore_In = In;
+    uint8_t* ToStore_Before = BeforeData;
+    uint8_t* ToStore_After = AfterData;
+    uint8_t* ToStore_In = InData;
     bool IsUsingMask_FileName = false;
-    bool IsUsingMask_Before = false;
-    bool IsUsingMask_After = false;
+    bool IsUsingMask_BeforeData = false;
+    bool IsUsingMask_AfterData = false;
     if (!Unique)
     {
         if (!BlockCount)
@@ -245,22 +345,22 @@ void rawcooked::Parse()
                 FirstFrame_FileName = NULL;
                 FirstFrame_FileName_Size = 0;
             }
-            if (Before && Before_Size)
+            if (BeforeData && BeforeData_Size)
             {
-                FirstFrame_Before = new uint8_t[Before_Size];
-                memcpy(FirstFrame_Before, Before, Before_Size);
-                FirstFrame_Before_Size = Before_Size;
+                FirstFrame_Before = new uint8_t[BeforeData_Size];
+                memcpy(FirstFrame_Before, BeforeData, BeforeData_Size);
+                FirstFrame_Before_Size = BeforeData_Size;
             }
             else
             {
                 FirstFrame_Before = NULL;
                 FirstFrame_Before_Size = 0;
             }
-            if (After && After_Size)
+            if (AfterData && AfterData_Size)
             {
-                FirstFrame_After = new uint8_t[After_Size];
-                memcpy(FirstFrame_After, After, After_Size);
-                FirstFrame_After_Size = After_Size;
+                FirstFrame_After = new uint8_t[AfterData_Size];
+                memcpy(FirstFrame_After, AfterData, AfterData_Size);
+                FirstFrame_After_Size = AfterData_Size;
             }
             else
             {
@@ -276,21 +376,21 @@ void rawcooked::Parse()
                 ToStore_FileName[i] -= FirstFrame_FileName[i];
             IsUsingMask_FileName = true;
         }
-        if (Before && FirstFrame_Before)
+        if (BeforeData && FirstFrame_Before)
         {
-            ToStore_Before = new uint8_t[Before_Size];
-            memcpy(ToStore_Before, Before, Before_Size);
-            for (size_t i = 0; i < Before_Size || i < FirstFrame_Before_Size; i++)
+            ToStore_Before = new uint8_t[BeforeData_Size];
+            memcpy(ToStore_Before, BeforeData, BeforeData_Size);
+            for (size_t i = 0; i < BeforeData_Size || i < FirstFrame_Before_Size; i++)
                 ToStore_Before[i] -= FirstFrame_Before[i];
-            IsUsingMask_Before = true;
+            IsUsingMask_BeforeData = true;
         }
-        if (After && FirstFrame_After)
+        if (AfterData && FirstFrame_After)
         {
-            ToStore_After = new uint8_t[After_Size];
-            memcpy(ToStore_After, After, After_Size);
-            for (size_t i = 0; i < After_Size || i < FirstFrame_After_Size; i++)
+            ToStore_After = new uint8_t[AfterData_Size];
+            memcpy(ToStore_After, AfterData, AfterData_Size);
+            for (size_t i = 0; i < AfterData_Size || i < FirstFrame_After_Size; i++)
                 ToStore_After[i] -= FirstFrame_After[i];
-            IsUsingMask_After = true;
+            IsUsingMask_AfterData = true;
         }
     }
 
@@ -314,261 +414,125 @@ void rawcooked::Parse()
         Compressed_FileName = ToStore_FileName;
         Compressed_FileName_Size = 0;
     }
-    uint8_t* Compressed_MaskBefore = NULL;
-    uLongf Compressed_MaskBefore_Size = 0;
+    uint8_t* Compressed_MaskBeforeData = NULL;
+    uLongf Compressed_MaskBeforeData_Size = 0;
     if (!Unique && FirstFrame_Before)
     {
-        Compressed_MaskBefore = new uint8_t[FirstFrame_Before_Size];
-        Compressed_MaskBefore_Size = (uLongf)FirstFrame_Before_Size;
-        if (compress((Bytef*)Compressed_MaskBefore, &Compressed_MaskBefore_Size, (const Bytef*)FirstFrame_Before, (uLong)FirstFrame_Before_Size) < 0)
+        Compressed_MaskBeforeData = new uint8_t[FirstFrame_Before_Size];
+        Compressed_MaskBeforeData_Size = (uLongf)FirstFrame_Before_Size;
+        if (compress((Bytef*)Compressed_MaskBeforeData, &Compressed_MaskBeforeData_Size, (const Bytef*)FirstFrame_Before, (uLong)FirstFrame_Before_Size) < 0)
         {
-            Compressed_MaskBefore = FirstFrame_Before;
-            Compressed_MaskBefore_Size = 0;
+            Compressed_MaskBeforeData = FirstFrame_Before;
+            Compressed_MaskBeforeData_Size = 0;
         }
     }
-    uint8_t* Compressed_Before = new uint8_t[Before_Size];
-    uLongf Compressed_Before_Size = (uLongf)Before_Size;
-    if (compress((Bytef*)Compressed_Before, &Compressed_Before_Size, (const Bytef*)ToStore_Before, (uLong)Before_Size) < 0)
+    uint8_t* Compressed_BeforeData = new uint8_t[BeforeData_Size];
+    uLongf Compressed_BeforeData_Size = (uLongf)BeforeData_Size;
+    if (compress((Bytef*)Compressed_BeforeData, &Compressed_BeforeData_Size, (const Bytef*)ToStore_Before, (uLong)BeforeData_Size) < 0)
     {
-        Compressed_Before = ToStore_Before;
-        Compressed_Before_Size = 0;
+        Compressed_BeforeData = ToStore_Before;
+        Compressed_BeforeData_Size = 0;
     }
-    uint8_t* Compressed_MaskAfter = NULL;
-    uLongf Compressed_MaskAfter_Size = 0;
+    uint8_t* Compressed_MaskAfterData = NULL;
+    uLongf Compressed_MaskAfterData_Size = 0;
     if (!Unique && FirstFrame_After)
     {
-        Compressed_MaskAfter = new uint8_t[FirstFrame_After_Size];
-        Compressed_MaskAfter_Size = (uLongf)FirstFrame_After_Size;
-        if (compress((Bytef*)Compressed_MaskAfter, &Compressed_MaskAfter_Size, (const Bytef*)FirstFrame_After, (uLong)FirstFrame_After_Size) < 0)
+        Compressed_MaskAfterData = new uint8_t[FirstFrame_After_Size];
+        Compressed_MaskAfterData_Size = (uLongf)FirstFrame_After_Size;
+        if (compress((Bytef*)Compressed_MaskAfterData, &Compressed_MaskAfterData_Size, (const Bytef*)FirstFrame_After, (uLong)FirstFrame_After_Size) < 0)
         {
-            Compressed_MaskAfter = FirstFrame_After;
-            Compressed_MaskAfter_Size = 0;
+            Compressed_MaskAfterData = FirstFrame_After;
+            Compressed_MaskAfterData_Size = 0;
         }
     }
-    uint8_t* Compressed_After = new uint8_t[After_Size];
-    uLongf Compressed_After_Size = (uLongf)After_Size;
-    if (compress((Bytef*)Compressed_After, &Compressed_After_Size, (const Bytef*)ToStore_After, (uLong)After_Size) < 0)
+    uint8_t* Compressed_AfterData = new uint8_t[AfterData_Size];
+    uLongf Compressed_AfterData_Size = (uLongf)AfterData_Size;
+    if (compress((Bytef*)Compressed_AfterData, &Compressed_AfterData_Size, (const Bytef*)ToStore_After, (uLong)AfterData_Size) < 0)
     {
-        Compressed_After = ToStore_After;
-        Compressed_After_Size = 0;
+        Compressed_AfterData = ToStore_After;
+        Compressed_AfterData_Size = 0;
     }
-    uint8_t* Compressed_In = new uint8_t[In_Size];
-    uLongf Compressed_In_Size = (uLongf)In_Size;
-    if (compress((Bytef*)Compressed_In, &Compressed_In_Size, (const Bytef*)ToStore_In, (uLong)In_Size) < 0)
+    uint8_t* Compressed_InData = new uint8_t[InData_Size];
+    uLongf Compressed_InData_Size = (uLongf)InData_Size;
+    if (compress((Bytef*)Compressed_InData, &Compressed_InData_Size, (const Bytef*)ToStore_In, (uLong)InData_Size) < 0)
     {
-        Compressed_In = ToStore_In;
-        Compressed_In_Size = 0;
-    }
-
-    uint64_t Out_Size = 0;
-
-    // SizeOnDisk computing - EBML header
-    uint64_t EBML_Size = 0;
-    uint64_t EBML_DocType_Size;
-    if (!File.IsOpen())
-    {
-        EBML_DocType_Size = strlen(DocType);
-        EBML_Size += Size_EB(Name_EBML_Doctype, EBML_DocType_Size);
-        EBML_Size += Size_EB(Name_EBML_DoctypeVersion, 1);
-        EBML_Size += Size_EB(Name_EBML_DoctypeReadVersion, 1);
+        Compressed_InData = ToStore_In;
+        Compressed_InData_Size = 0;
     }
 
-    // SizeOnDisk computing - Library name/version
-    uint64_t Segment_Size = 0;
-    uint64_t LibraryName_Size;
-    uint64_t LibraryVersion_Size;
-    if (!File.IsOpen())
+    ebml_writer Writer;
+    for (uint8_t Pass = 0; Pass < 2; Pass++)
     {
-        LibraryName_Size = strlen(LibraryName);
-        Segment_Size += Size_EB(Name_RawCooked_LibraryName, LibraryName_Size);
-        LibraryVersion_Size = strlen(LibraryVersion);
-        Segment_Size += Size_EB(Name_RawCooked_LibraryVersion, LibraryVersion_Size);
-    }
-
-    // SizeOnDisk computing - Track part
-    uint64_t Track_Size = 0;
-    if (!BlockCount)
-    {
-        if (!Unique && FirstFrame_FileName)
-            Track_Size += Size_EB(Name_RawCooked_MaskBaseFileName, Size_EB(Compressed_MaskFileName_Size ? FirstFrame_FileName_Size : 0) + (Compressed_MaskFileName_Size ? Compressed_MaskFileName_Size : FirstFrame_FileName_Size));
-        if (!Unique && FirstFrame_Before)
-            Track_Size += Size_EB(Name_RawCooked_MaskBaseBeforeData, Size_EB(Compressed_MaskBefore_Size ? FirstFrame_Before_Size : 0) + (Compressed_MaskBefore_Size ? Compressed_MaskBefore_Size : FirstFrame_Before_Size));
-        if (!Unique && FirstFrame_After)
-            Track_Size += Size_EB(Name_RawCooked_MaskBaseAfterData, Size_EB(Compressed_MaskAfter_Size ? FirstFrame_After_Size : 0) + (Compressed_MaskAfter_Size ? Compressed_MaskAfter_Size : FirstFrame_After_Size));
-    }
-
-    // SizeOnDisk computing - Block part
-    uint64_t Block_Size = 0;
-    uint64_t BeforeData_Size = 0;
-    uint64_t FileNameData_Size = 0;
-    if (Compressed_FileName_Size || FileName_Size)
-    {
-        FileNameData_Size = Size_EB(Compressed_FileName_Size ? FileName_Size : 0) + (Compressed_FileName_Size ? Compressed_FileName_Size : FileName_Size); // size then data
-        Block_Size += Size_EB(Name_RawCooked_FileName, FileNameData_Size);
-    }
-    if (Compressed_Before_Size || Before_Size)
-    {
-        BeforeData_Size = Size_EB(Compressed_Before_Size ? Before_Size : 0) + (Compressed_Before_Size ? Compressed_Before_Size : Before_Size); // size then data
-        Block_Size += Size_EB(Name_RawCooked_BeforeData, BeforeData_Size);
-    }
-    uint64_t AfterData_Size = 0;
-    if (Compressed_After_Size || After_Size)
-    {
-        AfterData_Size = Size_EB(Compressed_After_Size ? After_Size : 0) + (Compressed_After_Size ? Compressed_After_Size : After_Size); // size then data
-        Block_Size += Size_EB(Name_RawCooked_AfterData, AfterData_Size);
-    }
-    uint64_t InData_Size = 0;
-    if (Compressed_In_Size || In_Size)
-    {
-        InData_Size = Size_EB(Compressed_In_Size ? In_Size : 0) + (Compressed_In_Size ? Compressed_In_Size : In_Size); // size then data
-        Block_Size += Size_EB(Name_RawCooked_InData, InData_Size);
-    }
-    if (HashValue)
-    {
-        Block_Size += Size_EB(Name_RawCooked_FileHash, Size_Number(HashFormat_MD5) + HashValue->size());
-    }
-    if (FileSize != (uint64_t)-1)
-    {
-        Block_Size += Size_EB(Name_RawCooked_FileSize, Size_Number(FileSize));
-    }
-
-    // Case if the file is unique
-    if (Unique)
-    {
-        Track_Size += Block_Size;
-        Block_Size = 0;
-    }
-
-    // SizeOnDisk computing - Headers
-    if (EBML_Size)
-        Out_Size += Size_EB(Name_EBML, EBML_Size);
-    if (Segment_Size)
-        Out_Size += Size_EB(Name_RawCookedSegment, Segment_Size);
-    if (Track_Size)
-        Out_Size += Size_EB(IsAttachment ? Name_RawCookedAttachment : Name_RawCookedTrack, Track_Size);
-    if (Block_Size)
-        Out_Size += Size_EB(Name_RawCookedBlock, Block_Size);
-
-    // Fill
-    uint8_t* Out = new uint8_t[Out_Size];
-    size_t Out_Offset = 0;
-
-    // Fill - EBML part
-    if (EBML_Size)
-    {
-        Put_EB(Out, Out_Offset, Name_EBML, EBML_Size);
-        Put_EB(Out, Out_Offset, Name_EBML_Doctype, EBML_DocType_Size);
-        memcpy(Out + Out_Offset, DocType, EBML_DocType_Size);
-        Out_Offset += EBML_DocType_Size;
-        Put_EB(Out, Out_Offset, Name_EBML_DoctypeVersion, 1);
-        Out[Out_Offset]=DocTypeVersion;
-        Out_Offset += 1;
-        Put_EB(Out, Out_Offset, Name_EBML_DoctypeReadVersion, 1);
-        Out[Out_Offset] = DocTypeReadVersion;
-        Out_Offset += 1;
-    }
-
-    // Fill - Segment part
-    if (Segment_Size)
-    {
-        Put_EB(Out, Out_Offset, Name_RawCookedSegment, Segment_Size);
-        Put_EB(Out, Out_Offset, Name_RawCooked_LibraryName, LibraryName_Size);
-        memcpy(Out + Out_Offset, LibraryName, LibraryName_Size);
-        Out_Offset += LibraryName_Size;
-        Put_EB(Out, Out_Offset, Name_RawCooked_LibraryVersion, LibraryVersion_Size);
-        memcpy(Out + Out_Offset, LibraryVersion, LibraryVersion_Size);
-        Out_Offset += LibraryVersion_Size;
-    }
-
-    // Fill - Track part
-    if (Track_Size)
-    {
-        Put_EB(Out, Out_Offset, IsAttachment ? Name_RawCookedAttachment : Name_RawCookedTrack, Track_Size);
-        if (!Unique && FirstFrame_FileName)
+        // EBML header
+        if (!File.IsOpen())
         {
-            Put_EB(Out, Out_Offset, Name_RawCooked_MaskBaseFileName, Size_EB(Compressed_MaskFileName_Size ? FirstFrame_FileName_Size : 0) + (Compressed_MaskFileName_Size ? Compressed_MaskFileName_Size : FirstFrame_FileName_Size));
-            Put_EB(Out, Out_Offset, Compressed_MaskFileName_Size ? FirstFrame_FileName_Size : 0);
-            memcpy(Out + Out_Offset, Compressed_MaskFileName, (Compressed_MaskFileName_Size ? Compressed_MaskFileName_Size : FirstFrame_FileName_Size));
-            Out_Offset += (Compressed_MaskFileName_Size ? Compressed_MaskFileName_Size : FirstFrame_FileName_Size);
+            Writer.Block_Begin(Name_EBML);
+            Writer.String(Name_EBML_Doctype, DocType);
+            Writer.Number(Name_EBML_DoctypeVersion, 1);
+            Writer.Number(Name_EBML_DoctypeReadVersion, 1);
+            Writer.Block_End();
         }
-        if (!Unique && FirstFrame_Before)
-        {
-            Put_EB(Out, Out_Offset, Name_RawCooked_MaskBaseBeforeData, Size_EB(Compressed_MaskBefore_Size ? FirstFrame_Before_Size : 0) + (Compressed_MaskBefore_Size ? Compressed_MaskBefore_Size : FirstFrame_Before_Size));
-            Put_EB(Out, Out_Offset, Compressed_MaskBefore_Size ? FirstFrame_Before_Size : 0);
-            memcpy(Out + Out_Offset, Compressed_MaskBefore, (Compressed_MaskBefore_Size ? Compressed_MaskBefore_Size : FirstFrame_Before_Size));
-            Out_Offset += (Compressed_MaskBefore_Size ? Compressed_MaskBefore_Size : FirstFrame_Before_Size);
-        }
-        if (!Unique && FirstFrame_After)
-        {
-            Put_EB(Out, Out_Offset, Name_RawCooked_MaskBaseAfterData, Size_EB(Compressed_MaskAfter_Size ? FirstFrame_After_Size : 0) + (Compressed_MaskAfter_Size ? Compressed_MaskAfter_Size : FirstFrame_After_Size));
-            Put_EB(Out, Out_Offset, Compressed_MaskAfter_Size ? FirstFrame_After_Size : 0);
-            memcpy(Out + Out_Offset, Compressed_MaskAfter, (Compressed_MaskAfter_Size ? Compressed_MaskAfter_Size : FirstFrame_After_Size));
-            Out_Offset += (Compressed_MaskAfter_Size ? Compressed_MaskAfter_Size : FirstFrame_After_Size);
-        }
-    }
 
-    // Fill - Block part
-    if (Block_Size)
-        Put_EB(Out, Out_Offset, Name_RawCookedBlock, Block_Size);
-    if (FileNameData_Size)
-    {
-        Put_EB(Out, Out_Offset, IsUsingMask_FileName ? Name_RawCooked_MaskAdditionFileName : Name_RawCooked_FileName, FileNameData_Size);
-        Put_EB(Out, Out_Offset, Compressed_FileName_Size ? FileName_Size : 0);
-        memcpy(Out + Out_Offset, Compressed_FileName, (Compressed_FileName_Size ? Compressed_FileName_Size : FileName_Size));
-        Out_Offset += (Compressed_FileName_Size ? Compressed_FileName_Size : FileName_Size);
-    }
-    if (BeforeData_Size)
-    {
-        Put_EB(Out, Out_Offset, IsUsingMask_Before? Name_RawCooked_MaskAdditionBeforeData : Name_RawCooked_BeforeData, BeforeData_Size);
-        Put_EB(Out, Out_Offset, Compressed_Before_Size ? Before_Size : 0);
-        memcpy(Out + Out_Offset, Compressed_Before, (Compressed_Before_Size ? Compressed_Before_Size : Before_Size));
-        Out_Offset += (Compressed_Before_Size ? Compressed_Before_Size : Before_Size);
-    }
-    if (AfterData_Size)
-    {
-        Put_EB(Out, Out_Offset, IsUsingMask_After ? Name_RawCooked_MaskAdditionAfterData : Name_RawCooked_AfterData, AfterData_Size);
-        Put_EB(Out, Out_Offset, Compressed_After_Size ? After_Size : 0);
-        memcpy(Out + Out_Offset, Compressed_After, (Compressed_After_Size ? Compressed_After_Size : After_Size));
-        Out_Offset += (Compressed_After_Size ? Compressed_After_Size : After_Size);
-    }
-    if (InData_Size)
-    {
-        Put_EB(Out, Out_Offset, Name_RawCooked_InData, InData_Size);
-        Put_EB(Out, Out_Offset, Compressed_In_Size ? In_Size : 0);
-        memcpy(Out + Out_Offset, Compressed_In, (Compressed_In_Size ? Compressed_In_Size : In_Size));
-        Out_Offset += (Compressed_In_Size ? Compressed_In_Size : In_Size);
-    }
-    if (HashValue)
-    {
-        Put_EB(Out, Out_Offset, Name_RawCooked_FileHash, Size_Number(HashFormat_MD5) + HashValue->size());
-        Put_Number(Out, Out_Offset, HashFormat_MD5);
-        memcpy(Out + Out_Offset, HashValue->data(), HashValue->size());
-        Out_Offset += HashValue->size();
-    }
-    if (FileSize != (uint64_t)-1)
-    {
-        Put_EB(Out, Out_Offset, Name_RawCooked_FileSize, Size_Number(FileSize));
-        Put_Number(Out, Out_Offset, FileSize);
+        // Segment
+        if (!File.IsOpen())
+        {
+            Writer.Block_Begin(Name_RawCookedSegment);
+            Writer.String(Name_RawCooked_LibraryName, LibraryName);
+            Writer.String(Name_RawCooked_LibraryVersion, LibraryVersion);
+            Writer.Block_End();
+        }
+
+        // Track (or attachment) only
+        if (!BlockCount)
+        {
+            Writer.Block_Begin(IsAttachment ? Name_RawCookedAttachment : Name_RawCookedTrack);
+            if (!Unique && FirstFrame_FileName)
+                Writer.CompressableData(Name_RawCooked_MaskBaseFileName, Compressed_MaskFileName, FirstFrame_FileName_Size, Compressed_MaskFileName_Size);
+            if (!Unique && FirstFrame_Before)
+                Writer.CompressableData(Name_RawCooked_MaskBaseBeforeData, Compressed_MaskBeforeData, FirstFrame_Before_Size, Compressed_MaskBeforeData_Size);
+            if (!Unique && FirstFrame_After)
+                Writer.CompressableData(Name_RawCooked_MaskBaseAfterData, Compressed_MaskAfterData, FirstFrame_After_Size, Compressed_MaskAfterData_Size);
+            if (!Unique)
+                Writer.Block_End();
+        }
+
+        // Block only
+        if (BlockCount || !Unique)
+            Writer.Block_Begin(Name_RawCookedBlock);
+
+        // Common to track and block parts
+        Writer.CompressableData(IsUsingMask_FileName ? Name_RawCooked_MaskAdditionFileName : Name_RawCooked_FileName, Compressed_FileName, FileName_Size, Compressed_FileName_Size);
+        Writer.CompressableData(IsUsingMask_BeforeData ? Name_RawCooked_MaskAdditionBeforeData : Name_RawCooked_BeforeData, Compressed_BeforeData, BeforeData_Size, Compressed_BeforeData_Size);
+        Writer.CompressableData(IsUsingMask_AfterData ? Name_RawCooked_MaskAdditionAfterData : Name_RawCooked_AfterData, Compressed_AfterData, AfterData_Size, Compressed_AfterData_Size);
+        Writer.CompressableData(Name_RawCooked_InData, Compressed_InData, InData_Size, Compressed_InData_Size);
+        if (HashValue)
+            Writer.DataWithEncodedPrefix(Name_RawCooked_FileHash, HashFormat_MD5, HashValue->size(), HashValue->data());
+        if (FileSize != (uint64_t)-1)
+            Writer.Number(Name_RawCooked_FileSize, FileSize);
+        Writer.Block_End();
+
+        // Init 2nd pass
+        Writer.Set2ndPass();
     }
 
     // Write
-    WriteToDisk(Out, Out_Size);
+    WriteToDisk(Writer.GetBuffer(), Writer.GetBufferSize());
     BlockCount++;
 
     // Clean up
     if (Compressed_FileName_Size)
         delete[] Compressed_FileName;
-    if (Compressed_Before_Size)
-        delete[] Compressed_Before;
-    if (Compressed_After_Size)
-        delete[] Compressed_After;
-    if (Compressed_In_Size)
-        delete[] Compressed_In;
+    if (Compressed_BeforeData_Size)
+        delete[] Compressed_BeforeData;
+    if (Compressed_AfterData_Size)
+        delete[] Compressed_AfterData;
+    if (Compressed_InData_Size)
+        delete[] Compressed_InData;
     if (IsUsingMask_FileName)
         delete[] ToStore_FileName;
-    if (IsUsingMask_Before)
+    if (IsUsingMask_BeforeData)
         delete[] ToStore_Before;
-    if (IsUsingMask_After)
+    if (IsUsingMask_AfterData)
         delete[] ToStore_After;
 }
 

--- a/Source/Lib/RAWcooked/RAWcooked.h
+++ b/Source/Lib/RAWcooked/RAWcooked.h
@@ -27,14 +27,14 @@ public:
 
     bool                        Unique; // If set, data is for the whole stream (unique file)
 
-    uint8_t*                    Before;
-    uint64_t                    Before_Size;
+    uint8_t*                    BeforeData;
+    uint64_t                    BeforeData_Size;
 
-    uint8_t*                    After;
-    uint64_t                    After_Size;
+    uint8_t*                    AfterData;
+    uint64_t                    AfterData_Size;
 
-    uint8_t*                    In;
-    uint64_t                    In_Size;
+    uint8_t*                    InData;
+    uint64_t                    InData_Size;
 
     md5*                        HashValue = nullptr;
     bool                        IsAttachment = false;

--- a/Source/Lib/TIFF/TIFF.cpp
+++ b/Source/Lib/TIFF/TIFF.cpp
@@ -636,12 +636,12 @@ void tiff::ParseBuffer()
     if (IsSupported() && RAWcooked)
     {
         RAWcooked->Unique = false;
-        RAWcooked->Before = Buffer;
-        RAWcooked->Before_Size = StripOffsets[0];
-        RAWcooked->After = Buffer + Buffer_Size - EndOfImagePadding;
-        RAWcooked->After_Size = EndOfImagePadding;
-        RAWcooked->In = nullptr;
-        RAWcooked->In_Size = 0;
+        RAWcooked->BeforeData = Buffer;
+        RAWcooked->BeforeData_Size = StripOffsets[0];
+        RAWcooked->AfterData = Buffer + Buffer_Size - EndOfImagePadding;
+        RAWcooked->AfterData_Size = EndOfImagePadding;
+        RAWcooked->InData = nullptr;
+        RAWcooked->InData_Size = 0;
         RAWcooked->FileSize = Buffer_Size;
         if (Actions[Action_Hash])
         {

--- a/Source/Lib/WAV/WAV.cpp
+++ b/Source/Lib/WAV/WAV.cpp
@@ -330,12 +330,12 @@ void wav::WAVE_data()
     if (IsSupported() && RAWcooked)
     {
         RAWcooked->Unique = true;
-        RAWcooked->Before = Buffer;
-        RAWcooked->Before_Size = Buffer_Offset;
-        RAWcooked->After = Buffer + Levels[Level].Offset_End;
-        RAWcooked->After_Size = Buffer_Size - Levels[Level].Offset_End;
-        RAWcooked->In = nullptr;
-        RAWcooked->In_Size = 0;
+        RAWcooked->BeforeData = Buffer;
+        RAWcooked->BeforeData_Size = Buffer_Offset;
+        RAWcooked->AfterData = Buffer + Levels[Level].Offset_End;
+        RAWcooked->AfterData_Size = Buffer_Size - Levels[Level].Offset_End;
+        RAWcooked->InData = nullptr;
+        RAWcooked->InData_Size = 0;
         RAWcooked->FileSize = (uint64_t)-1;
         if (Actions[Action_Hash])
         {


### PR DESCRIPTION
Usage of "size is unknown" (0xFF, 0xFFFF...) reserved values by RAWcooked as normal sizes is not an issue if RAWcooked is the only one reader (nothing is lost, all files are still read and reversibility is OK everywhere), but 1/ this is conform to EBML spec 2/ another reader could misinterpret the content (for instance, [MediaInfo](https://mediaarea.net/MediaInfo) has this issue).
These values are not written anymore, but still read as normal size (in order to support old files having this non conforming value).

The PR includes also some refactoring of the RAWcooked parser file and a fix for a corner case I may be the only one to use and only when I test (` --display-command` used several times and with resulting file not deleted, and overwritten version must be smaller than the previous file).