### PR TITLE
Support of DPX files with image offset to data set to 0

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -45,6 +45,7 @@ Formats/AIFF/Flavors/96000_8_6_S/96000_8_6_S.aiff pass
 Formats/AIFF/Flavors/96000_8_6_U/96000_8_6_U.aiff pass
 Formats/DPX/Features/EndOfImagePadding/cropped_DPX_137_4K_10bit.dpx pass
 Formats/DPX/Features/JunkAfterData/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.Padding.dpx pass
+Formats/DPX/Features/OffsetToData/8bit-OffsetToData0.dpx pass
 Formats/DPX/Flavors/A_8_Packed_BE/Alpha_8_bit.dpx fail
 Formats/DPX/Flavors/RGBA_8_FilledA_BE/checkerboard_1080p_nuke_bigendian_8bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_8_Packed_BE/8bit_a.dpx pass

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -258,10 +258,15 @@ void dpx::ParseBuffer()
     uint16_t Packing = Get_X2();
     uint16_t Encoding = Get_X2();
     uint32_t OffsetToData = Get_X4();
-    if (OffsetToData < 1664 || OffsetToData > Buffer_Size)
-        Undecodable(undecodable::OffsetToData);
-    if (OffsetToImageData != OffsetToData)
-        Unsupported(unsupported::OffsetToImageData); // FFmpeg specific, it prioritizes OffsetToImageData over OffsetToData. TODO: remove this limitation when future internal encoder is used
+    if (OffsetToData)
+    {
+        if (OffsetToData < 1664 || OffsetToData > Buffer_Size)
+            Undecodable(undecodable::OffsetToData);
+        if (OffsetToImageData != OffsetToData)
+            Unsupported(unsupported::OffsetToImageData); // FFmpeg specific, it prioritizes OffsetToImageData over OffsetToData. TODO: remove this limitation when future internal encoder is used
+    }
+    else
+        OffsetToData = OffsetToImageData;
     if (Get_X4() != 0)
         Unsupported(unsupported::EolPadding);
    


### PR DESCRIPTION
It was reported that some scanners e.g. HDS+ from FilmFabriek fill image "data to offset" (Field 21.12 from specs) with a value of 0 instead of the real value.
Let's support that (FFmpeg does too by picking field 2, so it is fine and we do same).

Note: I'll add a implementation check about that, so the `--conch` option will trigger an error for such kind of file in a near future.