### PR TITLE
Accept DittoKey == 0xFFFFFFFF

### DIFF
--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -685,7 +685,7 @@ void dpx::ConformanceCheck()
     if (TotalImageFileSize != Buffer_Size)
         Invalid(invalid::TotalImageFileSize);
     uint32_t DittoKey = Get_X4();
-    if (DittoKey > 1)
+    if (DittoKey > 1 && DittoKey != (uint32_t)-1)
         Invalid(invalid::DittoKey);
     Buffer_Offset = 770;
     uint16_t NumberOfElements = Get_X2();


### PR DESCRIPTION
Not explicitly indicated in spec but looks like it is valid (just in a general section that 0xFFFFFFFF is possible nearly everywhere when an integer value is unknown).

Should fix #223, cc @bturkus.