### PR TITLE
Check conformance of DPX also in compressed content

### DIFF
--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -50,7 +50,7 @@ clean() {
             status=1
             return ${status}
         fi
-        git clean -fdx
+        git clean -fdx >/dev/null 2>&1
     popd >/dev/null 2>&1
 }
 

--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -82,6 +82,7 @@ Formats/DPX/Flavors/RGB_16_Packed_BE/16bit.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/058142ce-aeb9-4f5c-b3c7-7590f09c757d_00090000.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_BE/RGB_16_bit.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_LE/Dufay_000001.dpx pass
+Formats/DPX/Conformance/0004_OffsetToImageData/0004_OffsetToImageData_000000.dpx fail
 Formats/TIFF/Features/MultipleContinuousStripOffsets/Lavc.tiff pass
 Formats/TIFF/Flavors/Raw_CMYK_8_U/flower-separated-contig-08.tif fail
 Formats/TIFF/Flavors/Raw_CMYK_8_U/flower-separated-planar-08.tif fail

--- a/Project/GNU/CLI/test/test1b.sh
+++ b/Project/GNU/CLI/test/test1b.sh
@@ -18,7 +18,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        run_rawcooked --file --check-padding -slices 4 -d "${file}"
+        run_rawcooked -y --conch --file --check-padding -slices 4 -d "${file}"
 
         # check expected result
         if [ "${want}" == "fail" ] ; then
@@ -36,6 +36,7 @@ while read line ; do
             clean
             continue
         fi
+        source_warnings=$(echo "${cmd_stderr}" | grep "Warning: ")
 
         # check result file generation
         run_ffmpeg "${cmd_stdout}"
@@ -54,11 +55,20 @@ while read line ; do
         fi
 
         # check decoding
-        run_rawcooked "${file}.mkv"
+        run_rawcooked --conch "${file}.mkv"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then
             clean
             continue
         fi
+
+        decoded_warnings=$(echo "${cmd_stderr}" | grep "Warning: ")
+        if [ "${source_warnings}" != "${decoded_warnings}" ] ; then
+            echo "NOK: ${test}/${file}, warnings differs between the source and the decoded files" >&${fd}
+            status=1
+            clean
+            continue
+        fi
+
         check_files "${file}" "${file}.mkv.RAWcooked/${file}"
         clean
     popd >/dev/null 2>&1

--- a/Project/GNU/CLI/test/test2.txt
+++ b/Project/GNU/CLI/test/test2.txt
@@ -14,3 +14,7 @@ Features/FileNaming 000dpx+000wav
 Formats/WAV/Features 2ExtraNullBytesInFmtChunk
 Formats/WAV/Features 4ExtraNullBytesInFmtChunk
 Formats/WAV/Features 24ExtraNullBytesInFmtChunk
+Formats/DPX/Conformance 0016_TotalImageFileSize
+Formats/DPX/Conformance 0020_DittoKey
+Formats/DPX/Conformance 0020_DittoKey_NotSame
+Formats/DPX/Conformance 0020_DittoKey_NotSet

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -418,11 +418,21 @@ int main(int argc, const char* argv[])
     if (!Value && Global.Errors.HasWarnings())
     {
         cerr << Global.Errors.ErrorMessage() << endl;
-        cerr << "Do you want to continue despite warnings ? [y/N] ";
-        string Result;
-        getline(cin, Result);
-        if (!(!Result.empty() && (Result[0] == 'Y' || Result[0] == 'y')))
-            Value = 1;
+        switch (Global.Mode)
+        {
+            case AlwaysNo: Value = 1; break;
+            case AlwaysYes: break;
+            default:
+                if ((!Value && Global.Actions[Action_Encode] && !Output.Streams.empty())
+                 || (Global.Check && !Global.Errors.HasErrors() && !Global.OutputFileName.empty() && !Output.Streams.empty()))
+                {
+                    cerr << "Do you want to continue despite warnings ? [y/N] ";
+                    string Result;
+                    getline(cin, Result);
+                    if (!(!Result.empty() && (Result[0] == 'Y' || Result[0] == 'y')))
+                        Value = 1;
+                }
+        }
     }
 
     // FFmpeg

--- a/Source/Lib/DPX/DPX.cpp
+++ b/Source/Lib/DPX/DPX.cpp
@@ -682,7 +682,7 @@ void dpx::ConformanceCheck()
         Invalid(invalid::OffsetToImageData);
     Buffer_Offset = 16;
     uint32_t TotalImageFileSize = Get_X4();
-    if (TotalImageFileSize != Buffer_Size)
+    if (TotalImageFileSize != FileSize)
         Invalid(invalid::TotalImageFileSize);
     uint32_t DittoKey = Get_X4();
     if (DittoKey > 1)

--- a/Source/Lib/Input_Base.cpp
+++ b/Source/Lib/Input_Base.cpp
@@ -35,10 +35,11 @@ input_base::~input_base()
 }
 
 //---------------------------------------------------------------------------
-bool input_base::Parse(filemap* FileMap_Source, uint8_t* Buffer_Source, size_t Buffer_Size_Source)
+bool input_base::Parse(filemap* FileMap_Source, uint8_t* Buffer_Source, size_t Buffer_Size_Source, size_t FileSize_Source)
 {
     ClearInfo();
     FileMap = FileMap_Source;
+    FileSize = FileSize_Source == (size_t)-1 ? Buffer_Size_Source : FileSize_Source;
     Buffer = Buffer_Source;
     Buffer_Size = Buffer_Size_Source;
     HashComputed = false;

--- a/Source/Lib/Input_Base.cpp
+++ b/Source/Lib/Input_Base.cpp
@@ -238,7 +238,16 @@ void input_base::Error(error::type Type, error::generic::code Code)
     if (HasBufferOverflow())
         return; // Next errors are not real, due to buffer overflow
     if (!HasErrors())
-        SetErrors();
+    {
+        switch (Type)
+        {
+            case error::Undecodable:
+            case error::Unsupported:
+                SetErrors();
+                break;
+            default:;
+        }
+    }
     if (Errors)
         Errors->Error(ParserCode, Type, Code);
 }

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -59,7 +59,7 @@ public:
     // Constructor/Destructor
     input_base(parser ParserCode);
     input_base(errors* Errors, parser ParserCode);
-    ~input_base();
+    virtual ~input_base();
 
     // Config
     bitset<Action_Max>          Actions;
@@ -67,7 +67,7 @@ public:
     string*                     FileName = nullptr;
 
     // Parse
-    bool                        Parse(uint8_t* Buffer, size_t Buffer_Size) { return Parse(nullptr, Buffer, Buffer_Size); }
+    bool                        Parse(uint8_t* Buffer, size_t Buffer_Size, size_t FileSize = (size_t)-1) { return Parse(nullptr, Buffer, Buffer_Size, FileSize); }
     bool                        Parse(filemap& FileMap) { return Parse(&FileMap, FileMap.Buffer, FileMap.Buffer_Size); }
 
     // Info
@@ -83,6 +83,7 @@ protected:
     virtual void                ParseBuffer() = 0;
     virtual void                BufferOverflow() = 0;
     filemap*                    FileMap;
+    size_t                      FileSize;
     unsigned char*              Buffer;
     size_t                      Buffer_Size;
     size_t                      Buffer_Offset;
@@ -116,7 +117,7 @@ protected:
 
 protected:
     // Actions
-    bool                        Parse(filemap* FileMap, uint8_t* Buffer, size_t Buffer_Size);
+    bool                        Parse(filemap* FileMap, uint8_t* Buffer, size_t Buffer_Size, size_t FileSize = (size_t)-1);
     void                        Hash();
 
     // Errors
@@ -134,7 +135,7 @@ class uncompressed
 public:
     // Constructor/Destructor
     uncompressed(bool IsSequence = false);
-    ~uncompressed();
+    virtual ~uncompressed();
 
     // Info
     flavor                      Flavor;
@@ -151,6 +152,7 @@ public:
     // Constructor/Destructor
     input_base_uncompressed(parser ParserCode, bool IsSequence = false) : input_base(ParserCode), uncompressed(IsSequence) {}
     input_base_uncompressed(errors* Errors, parser ParserCode, bool IsSequence = false) : input_base(Errors, ParserCode), uncompressed(IsSequence) {}
+    virtual ~input_base_uncompressed() {}
 };
 
 

--- a/Source/Lib/Matroska/Matroska_Common.cpp
+++ b/Source/Lib/Matroska/Matroska_Common.cpp
@@ -1502,60 +1502,14 @@ void matroska::Segment_Cluster_SimpleBlock()
                             }
                             if (TrackInfo_Current->DPX_Buffer_Pos == 0 && TrackInfo_Current->Frame.RawFrame->Pre)
                             {
-                                dpx DPX;
-                                DPX.Actions.set(Action_Encode);
-                                DPX.Actions.set(Action_AcceptTruncated);
-                                if (!DPX.Parse(TrackInfo_Current->Frame.RawFrame->Pre, TrackInfo_Current->Frame.RawFrame->Pre_Size))
-                                {
-                                    if (!DPX.IsSupported())
-                                    {
-                                        Undecodable(undecodable::ReversibilityData_UnreadableFrameHeader);
+                                if (GetFormatAndFlavor(TrackInfo_Current, new dpx(Errors), raw_frame::Flavor_DPX))
+                                    if (GetFormatAndFlavor(TrackInfo_Current, new tiff(Errors), raw_frame::Flavor_TIFF))
                                         return;
-                                    }
-                                    TrackInfo_Current->R_A->Flavor = raw_frame::Flavor_DPX;
-                                    TrackInfo_Current->R_A->Flavor_Private = DPX.Flavor;
-                                    TrackInfo_Current->R_B->Flavor = raw_frame::Flavor_DPX;
-                                    TrackInfo_Current->R_B->Flavor_Private = DPX.Flavor;
-                                }
-                                else
-                                {
-                                    tiff TIFF;
-                                    TIFF.Actions.set(Action_Encode);
-                                    TIFF.Actions.set(Action_AcceptTruncated);
-                                    unsigned char* Frame_Buffer;
-                                    size_t Frame_Buffer_Size;
-                                    if (TrackInfo_Current->DPX_FileSize && TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos] != (uint64_t)-1)
-                                    {
-                                        // TODO: more optimal method without allocation of the full file size and without new/delete
-                                        Frame_Buffer_Size = TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos];
-                                        Frame_Buffer = new uint8_t[Frame_Buffer_Size];
-                                        memcpy(Frame_Buffer, TrackInfo_Current->Frame.RawFrame->Pre, TrackInfo_Current->Frame.RawFrame->Pre_Size);
-                                        memcpy(Frame_Buffer + Frame_Buffer_Size - TrackInfo_Current->Frame.RawFrame->Post_Size, TrackInfo_Current->Frame.RawFrame->Post, TrackInfo_Current->Frame.RawFrame->Post_Size);
-                                    }
-                                    else
-                                    {
-                                        Frame_Buffer = TrackInfo_Current->Frame.RawFrame->Pre;
-                                        Frame_Buffer_Size = TrackInfo_Current->Frame.RawFrame->Pre_Size;
-                                    }
-                                    bool TiffParseResult = TIFF.Parse(Frame_Buffer, Frame_Buffer_Size);
-                                    if (TrackInfo_Current->DPX_FileSize && TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos] != (uint64_t)-1)
-                                        delete[] Frame_Buffer;
-                                    if (!TiffParseResult)
-                                    {
-                                        if (!TIFF.IsSupported())
-                                        {
-                                            Undecodable(undecodable::ReversibilityData_UnreadableFrameHeader);
-                                            return;
-                                        }
-                                        TrackInfo_Current->R_A->Flavor = raw_frame::Flavor_TIFF;
-                                        TrackInfo_Current->R_A->Flavor_Private = TIFF.Flavor;
-                                        TrackInfo_Current->R_B->Flavor = raw_frame::Flavor_TIFF;
-                                        TrackInfo_Current->R_B->Flavor_Private = TIFF.Flavor;
-                                    }
-                                }
                             }
                             {
                                 TrackInfo_Current->Frame.Read_Buffer_Continue(Buffer + Buffer_Offset + 4, Levels[Level].Offset_End - Buffer_Offset - 4);
+                                if (TrackInfo_Current->Frame.RawFrame->Pre && (Actions[Action_Conch] || Actions[Action_Coherency]))
+                                    ParseDecodedFrame(TrackInfo_Current);
                                 if (TrackInfo_Current->DPX_FileName && TrackInfo_Current->DPX_Buffer_Pos < TrackInfo_Current->DPX_Buffer_Count)
                                 {
 
@@ -1879,6 +1833,77 @@ void matroska::ProgressIndicator_Show()
         ShowRealTime(RealTime);
     }
     cerr << "                              \n"; // Clean up in case there is less content outputed than the previous time
+}
+
+//---------------------------------------------------------------------------
+bool matroska::GetFormatAndFlavor(trackinfo* TrackInfo_Current, input_base_uncompressed* PotentialParser, raw_frame::flavor Flavor)
+{
+    PotentialParser->Actions.set(Action_Encode);
+    PotentialParser->Actions.set(Action_AcceptTruncated);
+    unsigned char* Frame_Buffer;
+    size_t Frame_Buffer_Size;
+    if (TrackInfo_Current->DPX_FileSize && TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos] != (uint64_t)-1)
+    {
+        // TODO: more optimal method without allocation of the full file size and without new/delete
+        Frame_Buffer_Size = TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos];
+        Frame_Buffer = new uint8_t[Frame_Buffer_Size];
+        memcpy(Frame_Buffer, TrackInfo_Current->Frame.RawFrame->Pre, TrackInfo_Current->Frame.RawFrame->Pre_Size);
+        memcpy(Frame_Buffer + Frame_Buffer_Size - TrackInfo_Current->Frame.RawFrame->Post_Size, TrackInfo_Current->Frame.RawFrame->Post, TrackInfo_Current->Frame.RawFrame->Post_Size);
+    }
+    else
+    {
+        Frame_Buffer = TrackInfo_Current->Frame.RawFrame->Pre;
+        Frame_Buffer_Size = TrackInfo_Current->Frame.RawFrame->Pre_Size;
+    }
+    bool ParseResult = PotentialParser->Parse(Frame_Buffer, Frame_Buffer_Size);
+    if (TrackInfo_Current->DPX_FileSize && TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos] != (uint64_t)-1)
+        delete[] Frame_Buffer;
+    if (ParseResult)
+    {
+        delete PotentialParser;
+        return true;
+    }
+
+    if (!PotentialParser->IsSupported())
+    {
+        delete PotentialParser;
+        Undecodable(undecodable::ReversibilityData_UnreadableFrameHeader);
+        return true;
+    }
+    TrackInfo_Current->R_A->Flavor = Flavor;
+    TrackInfo_Current->R_A->Flavor_Private = PotentialParser->Flavor;
+    TrackInfo_Current->R_B->Flavor = Flavor;
+    TrackInfo_Current->R_B->Flavor_Private = PotentialParser->Flavor;
+
+    if (Actions[Action_Conch])
+        PotentialParser->Actions.set(Action_Conch);
+    if (Actions[Action_Coherency])
+        PotentialParser->Actions.set(Action_Coherency);
+    TrackInfo_Current->DecodedFrameParser = PotentialParser;
+    return false;
+}
+
+//---------------------------------------------------------------------------
+void matroska::ParseDecodedFrame(trackinfo* TrackInfo_Current)
+{
+    unsigned char* Frame_Buffer;
+    size_t Frame_Buffer_Size;
+    if (TrackInfo_Current->DPX_FileSize && TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos] != (uint64_t)-1)
+    {
+        // TODO: more optimal method without allocation of the full file size and without new/delete
+        Frame_Buffer_Size = TrackInfo_Current->DPX_FileSize[TrackInfo_Current->DPX_Buffer_Pos];
+        Frame_Buffer = new uint8_t[Frame_Buffer_Size];
+        memcpy(Frame_Buffer, TrackInfo_Current->Frame.RawFrame->Pre, TrackInfo_Current->Frame.RawFrame->Pre_Size);
+        memcpy(Frame_Buffer + Frame_Buffer_Size - TrackInfo_Current->Frame.RawFrame->Post_Size, TrackInfo_Current->Frame.RawFrame->Post, TrackInfo_Current->Frame.RawFrame->Post_Size);
+    }
+    else
+    {
+        Frame_Buffer = TrackInfo_Current->Frame.RawFrame->Pre;
+        Frame_Buffer_Size = TrackInfo_Current->Frame.RawFrame->Pre_Size;
+    }
+    bool ParseResult = TrackInfo_Current->DecodedFrameParser->Parse(Frame_Buffer, Frame_Buffer_Size, TrackInfo_Current->Frame.RawFrame->GetTotalSize());
+    if (Frame_Buffer != TrackInfo_Current->Frame.RawFrame->Pre)
+        delete[] Frame_Buffer;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Matroska/Matroska_Common.h
+++ b/Source/Lib/Matroska/Matroska_Common.h
@@ -206,6 +206,7 @@ private:
         size_t                  DPX_Buffer_Count;
         raw_frame*              R_A;
         raw_frame*              R_B;
+        input_base_uncompressed* DecodedFrameParser;
         flac_info*              FlacInfo;
         frame                   Frame;
         bool                    Unique;
@@ -234,6 +235,7 @@ private:
             DPX_Buffer_Count(0),
             R_A(nullptr),
             R_B(nullptr),
+            DecodedFrameParser(nullptr),
             FlacInfo(nullptr),
             Unique(false),
             Format(Format_None)
@@ -254,7 +256,9 @@ private:
     friend class                frame_writer;
 
     //Utils
-    void Uncompress(uint8_t* &Output, size_t &Output_Size);
+    bool GetFormatAndFlavor(trackinfo* TrackInfo, input_base_uncompressed* PotentialParser, raw_frame::flavor Flavor);
+    void ParseDecodedFrame(trackinfo* TrackInfo);
+    void Uncompress(uint8_t*& Output, size_t& Output_Size);
     void SanitizeFileName(uint8_t* &FileName, size_t &FileName_Size);
     void RejectIncompatibleVersions();
     void ProcessCodecPrivate_FFV1();

--- a/Source/Lib/RawFrame/RawFrame.cpp
+++ b/Source/Lib/RawFrame/RawFrame.cpp
@@ -77,3 +77,34 @@ void raw_frame::TIFF_Create(size_t colorspace_type, size_t width, size_t height,
         default: ;
     }
 }
+
+//---------------------------------------------------------------------------
+size_t raw_frame::GetFrameSize()
+{
+    size_t FrameSize = 0;
+
+    if (Buffer)
+        FrameSize += Buffer_Size;
+
+    for (size_t i = 0; i < Planes.size(); i++)
+        FrameSize += Planes[i]->Buffer_Size;
+
+    return FrameSize;
+}
+
+//---------------------------------------------------------------------------
+size_t raw_frame::GetTotalSize()
+{
+    size_t TotalSize = GetFrameSize();
+
+    if (In && In_Size > TotalSize)
+        TotalSize = In_Size; // Get max of GetFrameSize() and In_Size
+
+    if (Pre)
+        TotalSize += Pre_Size;
+
+    if (Post)
+        TotalSize += Post_Size;
+
+    return TotalSize;
+}

--- a/Source/Lib/RawFrame/RawFrame.h
+++ b/Source/Lib/RawFrame/RawFrame.h
@@ -104,6 +104,10 @@ public:
     // Creation
     void Create(size_t colorspace_type, size_t width, size_t height, size_t bits_per_raw_sample, bool chroma_planes, bool alpha_plane, size_t h_chroma_subsample, size_t v_chroma_subsample);
 
+    // Info
+    size_t GetFrameSize();
+    size_t GetTotalSize();
+
 private:
     void FFmpeg_Create(size_t colorspace_type, size_t width, size_t height, size_t bits_per_raw_sample, bool chroma_planes, bool alpha_plane, size_t h_chroma_subsample, size_t v_chroma_subsample);
     void DPX_Create(size_t colorspace_type, size_t width, size_t height, size_t bits_per_raw_sample, bool chroma_planes, bool alpha_plane, size_t h_chroma_subsample, size_t v_chroma_subsample);


### PR DESCRIPTION
with `rawcooked --check --conch YourCompressedFile.mkv`, we report also the conformance issues found in the DPX content before compression.

So warnings due to conformance issues with `rawcooked --conch YourDirectory` are reproduced without needing to uncompress the content.

cc @bturkus.