### PR TITLE
Force output video frame count in FFmpeg command

### DIFF
--- a/Source/CLI/Input.h
+++ b/Source/CLI/Input.h
@@ -24,7 +24,7 @@ public:
 
     // Commands
     int AnalyzeInputs(global& Global);
-    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, string& FileName_StartNumber, string& FileName_EndNumber, bitset<Action_Max> const& Actions, errors* Errors = nullptr);
+    void DetectSequence(bool CheckIfFilesExist, size_t AllFiles_Pos, vector<string>& RemovedFiles, size_t& Path_Pos, string& FileName_Template, size_t& FrameCount, string& FileName_StartNumber, string& FileName_EndNumber, bitset<Action_Max> const& Actions, errors* Errors = nullptr);
 
     // Checks
     static void CheckDurations(vector<double> const& Durations, vector<string> const& Durations_FileName, errors* Errors = nullptr);

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -75,16 +75,12 @@ struct parse_info
     string Flavor;
     string Slices;
     input_info InputInfo;
-    bool   IsDetected;
-    bool   Problem;
+    size_t FrameCount = 0;
+    bool   IsDetected = false;
+    bool   Problem = false;
 
     bool ParseFile_Input(input_base& Input);
     bool ParseFile_Input(input_base_uncompressed& SingleFile, input& Input, size_t Files_Pos);
-
-    parse_info():
-        IsDetected(false),
-        Problem(false)
-    {}
 };
 
 //---------------------------------------------------------------------------
@@ -134,7 +130,7 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
     // Management
     Flavor = SingleFile.Flavor_String();
     if (SingleFile.IsSequence)
-        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FileName_StartNumber, FileName_EndNumber, Global.Actions, &Global.Errors);
+        Input.DetectSequence(Global.HasAtLeastOneFile, Files_Pos, RemovedFiles, Global.Path_Pos_Global, FileName_Template, FrameCount, FileName_StartNumber, FileName_EndNumber, Global.Actions, &Global.Errors);
     if (RemovedFiles.empty())
         RemovedFiles.push_back(*Name);
     else
@@ -268,6 +264,7 @@ int ParseFile_Uncompressed(parse_info& ParseInfo, size_t Files_Pos)
         }
         else if (ParseInfo.InputInfo.FrameRate)
             Stream.FrameRate = to_string(ParseInfo.InputInfo.FrameRate);
+        Stream.FrameCount = ParseInfo.InputInfo.FrameCount;
 
         Output.Streams.push_back(Stream);
 

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -141,9 +141,20 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
         for (size_t i = 0; i < Streams.size(); i++)
         {
             stringstream t;
-            t << MapPos++;
+            t << MapPos;
             Command += " -map ";
             Command += t.str();
+
+            // Force frame count
+            if (Streams[i].FrameCount)
+            {
+                Command += " -frames:";
+                Command += to_string(i);
+                Command += ' ';
+                Command += to_string(Streams[i].FrameCount);
+            }
+
+            MapPos++;
         }
     }
     else

--- a/Source/CLI/Output.h
+++ b/Source/CLI/Output.h
@@ -27,11 +27,8 @@ struct stream
     string                      Flavor;
     string                      Slices;
     string                      FrameRate;
-    bool                        Problem;
-
-    stream()
-        : Problem(false)
-    {}
+    size_t                      FrameCount = 0;
+    bool                        Problem = false;
 };
 struct attachment
 {


### PR DESCRIPTION
Add ` -frames` option with the count of image files we detected for each video stream, as a security in order to avoid unexpected (from RAWcooked point fo view) FFmpeg behavior in case the count of video frames detected by FFmpeg is more than the count of video frames detected by RAWcooked.

e.g. 9.dpx, 10.dpx, RAWcooked detects 2 streams with 1 frame, FFmpeg detects 1 stream with 2 frames and 1 stream with 1 frames before this patch, and "only" 2 streams with 1 frames after this patch.

(RAWcooked is being fixed for that but I keep this patch with the hope that it would prevent other unexpected behavior due to any other difference between what RAWcooked expects and how FFmpeg behaves with reason)