### PR TITLE
Add more checks, detects truncated compressed files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,6 +57,8 @@ test_script:
     Run-Test test3
     Run-Test version
     Run-Test notfound
+    Run-Test check
+    Run-Test legacy
     Run-Test multiple
     Run-Test gaps
     Run-Test increasingdigitcount

--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -68,7 +68,7 @@ man1_MANS = ../../../Source/CLI/rawcooked.1
 
 AM_TESTS_FD_REDIRECT = 9>&2
 
-TESTS = test/test1.sh test/test1b.sh test/test2.sh test/test3.sh test/reversibilityfile.sh test/multiple.sh test/valgrind.sh test/overwrite.sh test/increasingdigitcount.sh test/gaps.sh test/slices.sh test/notfound.sh test/version.sh
+TESTS = test/test1.sh test/test1b.sh test/test2.sh test/test3.sh test/reversibilityfile.sh test/check.sh test/legacy.sh test/multiple.sh test/valgrind.sh test/overwrite.sh test/increasingdigitcount.sh test/gaps.sh test/slices.sh test/notfound.sh test/version.sh
 
 TESTING_DIR = test/TestingFiles
 

--- a/Project/GNU/CLI/test/check.sh
+++ b/Project/GNU/CLI/test/check.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+script_path="${PWD}/test"
+. ${script_path}/helpers.sh
+
+test="check"
+
+# local helper functions
+find_and_replace() {
+    local old="${1}" new="${2}" len="$((${#1} / 2))" file="${3}" size="$(${fsize} ${3})" occurence="${4}" chunk_size=256 pos=0 found=0
+    while ((pos < size)) ; do
+        local chunk="$(xxd -u -p -c ${chunk_size} -l ${chunk_size} -s ${pos} ${file})"
+        local prefix="${chunk%%${old}*}"
+
+        if ((${#prefix} < ${#chunk})) ; then
+            ((pos += ${#prefix} / 2))
+            ((found += 1))
+            if ((found == occurence)) ; then
+                break
+            fi
+            ((pos += len))
+            continue
+        fi
+        ((pos += chunk_size - len + 1))
+    done
+
+    ((found == occurence)) || fatal "internal" "pattern not found"
+
+    (echo "${new}" | xxd -r -p -l ${len} -s ${pos} - ${file}) || fatal "internal" "file patching failed"
+}
+
+find_and_truncate() {
+    local pattern="${1}" len="$((${#1} / 2))" file="${2}" size="$(${fsize} ${2})" occurence="${3}" chunk_size=256 pos=0 found=0
+    while ((pos < size)) ; do
+        local chunk="$(xxd -u -p -c ${chunk_size} -l ${chunk_size} -s ${pos} ${file})"
+        local prefix="${chunk%%${pattern}*}"
+
+        if ((${#prefix} < ${#chunk})) ; then
+            ((pos += ${#prefix} / 2))
+            ((found += 1))
+            if ((found == occurence)) ; then
+                break
+            fi
+            ((pos += len))
+            continue
+        fi
+        ((pos += chunk_size - len + 1))
+    done
+
+    ((found == occurence)) || fatal "internal" "pattern not found"
+    dd if="${file}" of="${file}.new" bs=1 count=${pos} >/dev/null 2>&1 || fatal "internal" "dd command failed"
+    mv -f "${file}.new" "${file}" || fatal "internal" "mv command failed"
+}
+
+pushd "${files_path}" >/dev/null 2>&1
+    directory="${test}"
+    file="${test}.mkv"
+
+    mkdir "${directory}"|| fatal "internal" "mkdir command failed"
+
+    # generate video and attachment source directory
+    ffmpeg -nostdin -f lavfi -i testsrc=size=16x16 -t 1 -start_number 0 "${directory}/%03d.dpx" >/dev/null 2>&1|| fatal "internal" "ffmpeg command failed"
+    echo "a" > "${directory}/attachment"
+
+    run_rawcooked -y "${directory}"
+    check_success "failed to generate mkv" "mkv generated"
+
+    cp -f "${file}" "${file}.orig" || fatal "internal" "cp command failed"
+
+    # valid mkv
+    run_rawcooked --check "${file}" -o ./
+    check_success "test failed on valid mkv with output set to source directory" "test succeeded on valid mkv with output set to source directory"
+    run_rawcooked --check "${file}"
+    check_success "test failed on valid mkv" "test succeeded on valid mkv"
+
+    # missing video frames
+    cp -f "${file}.orig" "${file}" || fatal "internal" "mv command failed"
+
+    find_and_truncate "1F43B675" "${file}" 1
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing video frames (first occurence) and output set to source directory" "test succeeded on mkv with missing video frames (first occurence) and output set to source directory"
+    run_rawcooked --check "${file}"
+    check_failure "test failed on mkv with missing video frames (first occurence)" "test succeeded on mkv with missing video frames (first occurence)"
+
+    cp -f "${file}.orig" "${file}" || fatal "internal" "mv command failed"
+
+    find_and_truncate "1F43B675" "${file}" 2
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing video frames (second occurence) and output set to source directory" "test succeeded on mkv with missing video frames (second occurence) and output set to source directory"
+    run_rawcooked --check "${file}"
+    check_failure "test failed on mkv with missing video frames (second occurence)" "test succeeded on mkv with missing video frames (second occurence)"
+
+    # missing attachment
+    cp -f "${file}.orig" "${file}" || fatal "internal" "mv command failed"
+
+    find_and_replace "61A70100" "EC80EC02" "${file}" 1
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing attachment and output set to source directory" "test succeeded on mkv with missing attachment and output set to source directory"
+    run_rawcooked --check "${file}"
+    check_failure "test failed on mkv mkv with missing attachment" "test missing on mkv with modified attachment"
+
+    # missing reversibility file
+    cp -f "${file}.orig" "${file}" || fatal "internal" "mv command failed"
+
+    find_and_replace "61A70100" "EC80EC02" "${file}" 2
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing reversibility file and output set to source directory" "test succeeded on mkv with missing reversibility file and output set to source directory"
+    run_rawcooked --check "${file}"
+    check_failure "test failed on mkv mkv with missing reversibility file" "test succeeded on mkv with missing reversibility file"
+
+    # missing attachment in source directory
+    rm -f "${directory}/attachment" || fatal "internal" "rm command failed"
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing attachment in source directory" "test succeeded on mkv with missing attachment in source directory"
+
+    # generate audio only source directory
+    rm -f "${directory}/*" "${file}" "${file}.orig" || fatal "internal" "rm command failed"
+    ffmpeg -nostdin -f lavfi -i anoisesrc=duration=60 "${directory}/audio.wav" >/dev/null 2>&1|| fatal "internal" "ffmpeg command failed"
+
+    run_rawcooked -y "${directory}"
+    check_success "failed to generate mkv" "mkv generated"
+
+    cp -f "${file}" "${file}.orig" || fatal "internal" "cp command failed"
+
+    # missing audio frames
+    cp -f "${file}.orig" "${file}" || fatal "internal" "mv command failed"
+
+    find_and_truncate "1F43B675" "${file}" 1
+    run_rawcooked --check "${file}" -o ./
+    check_failure "test failed on mkv with missing audio frames (first occurence) and output set to source directory" "test succeeded on mkv with missing audio frames (first occurence) and output set to source directory"
+    run_rawcooked --check "${file}"
+    check_failure "test failed on mkv with missing audio frames (first occurence)" "test succeeded on mkv with missing audio frames (first occurence)"
+
+    # cleaning
+    clean
+popd >/dev/null 2>&1
+
+exit ${status}

--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -14,7 +14,7 @@ if grep -q Microsoft /proc/version; then
 fi
 
 case "${OSTYPE}" in
-    linux*)
+    linux*|cygwin*)
         fsize="stat -c %s"
         ;;
     darwin*|bsd*)
@@ -169,7 +169,7 @@ check_directories() {
     local directory2="${2}"
     local files
 
-    files=$(find "${directory1}" -type f  ! -empty -print)
+    files=$(find "${directory1}" -type f -print)
 
     for f in ${files} ; do
         if [ ! -e  "${directory2}/${f}" ] ; then

--- a/Project/GNU/CLI/test/legacy.sh
+++ b/Project/GNU/CLI/test/legacy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+script_path="${PWD}/test"
+. ${script_path}/helpers.sh
+
+while read line ; do
+    file="$(basename "$(echo "${line}")")"
+    path="$(dirname "$(echo "${line}")")"
+    test=$(basename "${path}")
+
+    pushd "${files_path}/${path}" >/dev/null 2>&1
+        run_rawcooked ${file}
+
+        # check expected result
+        if check_success "command rejected" "command accepted" ; then
+           echo "OK: ${test}/${file}, command accepted at input" >&${fd}
+        fi
+
+        clean
+    popd >/dev/null 2>&1
+done < "${script_path}/legacy.txt"
+
+exit ${status}

--- a/Project/GNU/CLI/test/legacy.txt
+++ b/Project/GNU/CLI/test/legacy.txt
@@ -1,0 +1,10 @@
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.mkv --check
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.mkv --check -o ./
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200215.mkv --check
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200215.mkv --check -o ./
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200215all.mkv --check
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200215all.mkv --check -o ./
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200219.mkv --check
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200219.mkv --check -o ./
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200219all.mkv --check
+BuggyPackages/CompatibleVersion/RAWcooked_18.10.1/18.10.1.20200219all.mkv --check -o ./

--- a/Project/GNU/CLI/test/multiple.sh
+++ b/Project/GNU/CLI/test/multiple.sh
@@ -50,7 +50,7 @@ while read line ; do
         rm -f "${file}.mkv"
 
         # check result files
-        files="$(find * -path ${file}.mkv.RAWcooked -prune -o -type f ! -empty -print)"
+        files="$(find * -path ${file}.mkv.RAWcooked -prune -o -type f -print)"
 
         for f in ${files} ; do
             if [ ! -e  "${file}.mkv.RAWcooked/${f}" ] ; then

--- a/Project/GNU/CLI/test/overwrite.sh
+++ b/Project/GNU/CLI/test/overwrite.sh
@@ -255,6 +255,14 @@ case_4() {
     done
 }
 
+case_5() {
+    # corrupt last attachment
+    local attachments_count="$(ls 2>/dev/null -Ubad1 -- ${file}.mkv.RAWcooked/${file}/*.txt | wc -l)" || fatal "internal" "unable to list attachments files"
+    if [ "${attachments_count}" -gt "0" ] ; then
+        echo "attachment X" > ${file}.mkv.RAWcooked/${file}/$((attachments_count)).txt || fatal "internal" "unable to update file"
+    fi
+}
+
 access_readonly() {
     chmod -R 0440 "${file}.mkv.RAWcooked/${file}/"* || fatal "internal" "chmod command failed"
 }
@@ -335,13 +343,14 @@ command_y() {
 
 pushd "${files_path}" >/dev/null 2>&1
     files="1 2 3 4"
-    cases="normal 1 2 3 4"
+    cases="normal 1 2 3 4 5"
     accesses="normal readonly none"
     commands="n y"
 
     for file in ${files} ; do
         file_${file}
         for case in ${cases} ; do
+            ([ "${case}" == "5" ] && [ "${file}" != "4" ] ) && continue
             for access in ${accesses} ; do
                 for command in ${commands} ; do
                     command_${command}

--- a/Source/Lib/Config.h
+++ b/Source/Lib/Config.h
@@ -40,15 +40,14 @@ typedef std::array<uint8_t, 16> md5;
 
 //---------------------------------------------------------------------------
 // Platform specific
+inline void FormatPath(string& s)
+{
+    string::size_type i = 0;
+    while ((i = s.find('\\', i)) != string::npos)
+        s[i++] = '/';
+}
 #if defined(_WIN32) || defined(_WINDOWS)
-    inline void FormatPath(string& s)
-    {
-        string::size_type i = 0;
-        while ((i = s.find('\\', i)) != string::npos)
-            s[i++] = '/';
-    }
     static const char PathSeparator = '\\';
 #else
-    inline void FormatPath(string& s) {}
     static const char PathSeparator = '/';
 #endif

--- a/Source/Lib/HashSum/HashSum.cpp
+++ b/Source/Lib/HashSum/HashSum.cpp
@@ -60,8 +60,8 @@ const char** ErrorTexts[] =
 {
     undecodable::MessageText,
     nullptr,
-    invalid::MessageText,
     nullptr,
+    invalid::MessageText,
 };
 
 static_assert(error::Type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
@@ -104,6 +104,22 @@ void hashes::Ignore(string const& FileName)
 }
 
 //---------------------------------------------------------------------------
+void hashes::RemoveEmptyFiles()
+{
+    md5 EmptyMD5 = { 0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04, 0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e };
+
+    auto List_FromHashFiles_Size = List_FromHashFiles.size();
+    for (size_t i = 0; i < List_FromHashFiles_Size; i++)
+    {
+        if (List_FromHashFiles[i].MD5 == EmptyMD5)
+        {
+            List_FromHashFiles.erase(List_FromHashFiles.begin() + i);
+            List_FromHashFiles_Size--;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------
 void hashes::FromFile(string const& FileName, md5 const& MD5)
 {
     // Hash files maybe not yet there, we wait if we don't know that files are not all there
@@ -124,7 +140,7 @@ void hashes::FromFile(string const& FileName, md5 const& MD5)
         if (find(HashFiles.begin(), HashFiles.end(), FileName) == HashFiles.end())
         {
             if (Errors)
-                Errors->Error(IO_Hashes, WouldBeError ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileMissing : (error::generic::code)hashes_issue::invalid::FileHashMissing, FileName);
+                Errors->Error(IO_Hashes, CheckFromFiles ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileMissing : (error::generic::code)hashes_issue::invalid::FileHashMissing, FileName);
         }
     }
     else
@@ -135,7 +151,7 @@ void hashes::FromFile(string const& FileName, md5 const& MD5)
             if (File->MD5 != MD5)
             {
                 if (Errors)
-                    Errors->Error(IO_Hashes, WouldBeError ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileComparison : (error::generic::code)hashes_issue::invalid::FileHashComparison, FileName);
+                    Errors->Error(IO_Hashes, CheckFromFiles ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileComparison : (error::generic::code)hashes_issue::invalid::FileHashComparison, FileName);
             }
         }
     }
@@ -173,7 +189,7 @@ void hashes::Finish()
         if (!HashItem.Flags[hashes::value::Flag_IsFound])
         {
             if (Errors)
-                Errors->Error(IO_Hashes, WouldBeError ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileExtra : (error::generic::code)hashes_issue::invalid::FileHashExtra, HashItem.Name);
+                Errors->Error(IO_Hashes, CheckFromFiles ? error::Undecodable : error::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileExtra : (error::generic::code)hashes_issue::invalid::FileHashExtra, HashItem.Name);
         }
     }
 }
@@ -308,4 +324,5 @@ void hashsum::ParseBuffer()
     // Detected
     SetDetected();
     SetSupported();
+    RegisterAsAttachment();
 }

--- a/Source/Lib/HashSum/HashSum.h
+++ b/Source/Lib/HashSum/HashSum.h
@@ -57,6 +57,7 @@ public:
     void                        ResetHashFile(size_t OldSize); // Indicate that the new hash file is buggy, discard its content, use value from NewHashFile()
     void                        FromHashFile(string const& FileName, md5 const& MD5);
     void                        Ignore(string const& FileName);
+    void                        RemoveEmptyFiles();
     bool                        NoMoreHashFiles() { if (!IsSorted) NoMoreHashFiles_Internal(); return !List_FromHashFiles.empty(); } // Return true if Hashes are useful
     void                        FromFile(string const& FileName, md5 const& MD5);
     void                        Finish();

--- a/Source/Lib/Input_Base.cpp
+++ b/Source/Lib/Input_Base.cpp
@@ -269,7 +269,12 @@ uncompressed::~uncompressed()
 void unknown::ParseBuffer()
 {
     SetDetected();
+    RegisterAsAttachment();
+}
 
+//---------------------------------------------------------------------------
+void input_base_uncompressed::RegisterAsAttachment()
+{
     // Write RAWcooked file
     if (RAWcooked)
     {
@@ -280,7 +285,7 @@ void unknown::ParseBuffer()
         RAWcooked->AfterData_Size = 0;
         RAWcooked->InData = nullptr;
         RAWcooked->InData_Size = 0;
-        RAWcooked->FileSize = (uint64_t)-1;
+        RAWcooked->FileSize = FileSize;
         if (Actions[Action_Hash])
         {
             Hash();

--- a/Source/Lib/Input_Base.h
+++ b/Source/Lib/Input_Base.h
@@ -154,6 +154,9 @@ public:
     input_base_uncompressed(parser ParserCode, bool IsSequence = false) : input_base(ParserCode), uncompressed(IsSequence) {}
     input_base_uncompressed(errors* Errors, parser ParserCode, bool IsSequence = false) : input_base(Errors, ParserCode), uncompressed(IsSequence) {}
     virtual ~input_base_uncompressed() {}
+
+protected:
+    void                        RegisterAsAttachment();
 };
 
 

--- a/Source/Lib/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/RAWcooked/RAWcooked.cpp
@@ -48,7 +48,7 @@ static const uint32_t Name_RawCooked_FileHash = 0x20;
 // File number metadata
 static const uint32_t Name_RawCooked_FileSize = 0x30;
 static const uint32_t Name_RawCooked_MaskBaseFileSize = 0x31;     // In BlockGroup only
-static const uint32_t Name_RawCooked_MaskAdditionFileSize = 0x32; // In Track only
+static const uint32_t Name_RawCooked_MaskAdditionFileSize = 0x31; // In Track only
 // Global information
 static const uint32_t Name_RawCooked_LibraryName = 0x70;
 static const uint32_t Name_RawCooked_LibraryVersion = 0x71;


### PR DESCRIPTION
Add checks of the truncation of a compressed file when ` --check` is used.
A file is considered truncated also when the muxing fails.
(one sponsor found that sometimes the muxer fails without non zero exit code, and ` --check` was not catching that)

Add check of too many frames in the compressed file, in case of weird muxing.

Add check of missing attachments or extra attachement, in case there is some attachment muxing issue.