### PR TITLE
Option for outputing framemd5 file while compressing

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -128,6 +128,20 @@ int global::SetEncode(bool Value)
 }
 
 //---------------------------------------------------------------------------
+int global::SetFrameMd5(bool Value)
+{
+    FrameMd5 = true;
+    return 0;
+}
+
+//---------------------------------------------------------------------------
+int global::SetFrameMd5FileName(const char* FileName)
+{
+    FrameMd5FileName = FileName;
+    return 0;
+}
+
+//---------------------------------------------------------------------------
 int global::SetHash(bool Value)
 {
     Actions.set(Action_Hash, Value);
@@ -362,6 +376,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
     OutputFileName_IsProvided = false;
     Quiet = false;
     Check = false;
+    FrameMd5 = false;
     Actions.set(Action_Encode);
     Actions.set(Action_Coherency);
     Hashes = hashes(&Errors);
@@ -459,6 +474,20 @@ int global::ManageCommandLine(const char* argv[], int argc)
         else if (strcmp(argv[i], "--encode") == 0)
         {
             int Value = SetEncode(true);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--framemd5") == 0)
+        {
+            int Value = SetFrameMd5(true);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--framemd5-name") == 0)
+        {
+            if (i + 1 == argc)
+                return Error_Missing(argv[i]);
+            int Value = SetFrameMd5FileName(argv[++i]);
             if (Value)
                 return Value;
         }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -32,6 +32,7 @@ public:
     size_t                      AttachmentMaxSize;
     string                      rawcooked_reversibility_data_FileName;
     string                      OutputFileName;
+    string                      FrameMd5FileName;
     string                      BinName;
     string                      LicenseKey;
     bool                        IgnoreLicenseKey;
@@ -44,6 +45,7 @@ public:
     bool                        OutputFileName_IsProvided;
     bool                        Quiet;
     bool                        Check;
+    bool                        FrameMd5;
     bitset<Action_Max>          Actions;
 
     // Intermediate info
@@ -87,6 +89,8 @@ private:
     int SetCoherency(bool Value);
     int SetConch(bool Value);
     int SetEncode(bool Value);
+    int SetFrameMd5(bool Value);
+    int SetFrameMd5FileName(const char* FileName);
     int SetHash(bool Value);
     int SetAll(bool Value);
 

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -172,6 +172,16 @@ ReturnValue Help(const char* Name)
     cout << "              Don't do compute or test of hash of files. (see above)." << endl;
     cout << "              Is default if input is raw content (it may change in the future)" << endl;
     cout << endl;
+    cout << "       --framemd5" << endl;
+    cout << "              Compute the framemd5 of input frames and store it to a sidecar file." << endl;
+    cout << "              See FFmpeg framemd5 documentation for more information." << endl;
+    cout << "       --framemd5-name value" << endl;
+    cout << "              Set the name of the framemd5 file to value." << endl;
+    cout << "              Default value is ${Input}.framemd5." << endl;
+    cout << "       --no-framemd5" << endl;
+    cout << "              Don't do compute of framemd5 of input frames. (see above)." << endl;
+    cout << "              Is default." << endl;
+    cout << endl;
     cout << "INPUT RELATED OPTIONS" << endl;
     cout << "       --file" << endl;
     cout << "              Unlock compression of files (e.g. a .dpx or .wav)." << endl;

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -293,6 +293,24 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     Command += Global.OutputFileName;
     Command += '\"';
 
+    if (Global.FrameMd5)
+    {
+        if (Global.FrameMd5FileName.empty())
+        {
+            Global.FrameMd5FileName = FileName;
+            if (Global.FrameMd5FileName.back() == '/'
+            #if defined(_WIN32) || defined(_WINDOWS)
+                || Global.FrameMd5FileName.back() == '\\'
+            #endif // defined(_WIN32) || defined(_WINDOWS)
+                )
+                Global.FrameMd5FileName.pop_back();
+            Global.FrameMd5FileName += ".framemd5";
+        }
+        Command += " -f framemd5 \"";
+        Command += Global.FrameMd5FileName;
+        Command += '\"';
+    }
+
     // Info
     if (Problem)
     {

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -166,6 +166,21 @@ This is default when the input is a Matroska container and RAWcooked metadata co
 Do not compute or test the hash of the file (see above).
 .br
 This is default when the input is RAW content, but may change in the future.
+.TP
+.B --framemd5
+Compute the framemd5 of input frames and store it to a sidecar file.
+.br
+See FFmpeg framemd5 documentation for more information.
+.TP
+.B --framemd5-name \fIvalue\fR
+Set the name of the framemd5 file to \fIvalue\fR.
+.br
+Default value is \fI${Input}.framemd5\fR.
+.TP
+.B --no-framemd5
+Do not compute of framemd5 of input frames. (see above)."
+.br
+Is default.
 .SS INPUT RELATED OPTIONS
 .TP
 .B --file


### PR DESCRIPTION
Let's try to avoid to stress the storage more than needed, we could create the compressed file and the `framemd5` file at the same time.
`rawcooked DirectoryName --framemd5`
Output is 2 files: DirectoryName.mkv and DirectoryName.framemd5
@digitensions