### PR TITLE
Refactoring of RAWcooked reversibility file creation

### DIFF
--- a/Source/Lib/Compressed/Matroska/Matroska.cpp
+++ b/Source/Lib/Compressed/Matroska/Matroska.cpp
@@ -887,7 +887,7 @@ bool track_info::ParseDecodedFrame(input_base_uncompressed* Parser)
     auto FrameParser = Parser ? Parser : DecodedFrameParser;
     if (!FrameParser)
         return true;
-    auto FileSize = ReversibilityData->GetFileSize();
+    auto FileSize = ReversibilityData->FileSize();
     if (FileSize && FileSize != (uint64_t)-1)
     {
         auto Pre_Size = RawFrame->Pre().Size();
@@ -966,7 +966,7 @@ void matroska::Segment_Attachments_AttachedFile_FileData_RawCookedxxx_yyy(revers
 //---------------------------------------------------------------------------
 void matroska::StoreFromCurrentToEndOfElement(buffer &Output)
 {
-    Output.CopyExpand(Buffer.Data() + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
+    Output.Create(Buffer.Data() + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Compressed/RAWcooked/RAWcooked.h
+++ b/Source/Lib/Compressed/RAWcooked/RAWcooked.h
@@ -49,12 +49,9 @@ private:
     size_t                      BlockCount;
 
     // First frame info
-    uint8_t*                    FirstFrame_Before;
-    size_t                      FirstFrame_Before_Size;
-    uint8_t*                    FirstFrame_After;
-    size_t                      FirstFrame_After_Size;
-    uint8_t*                    FirstFrame_FileName;
-    size_t                      FirstFrame_FileName_Size;
+    buffer                      FirstFrame_Before;
+    buffer                      FirstFrame_After;
+    buffer                      FirstFrame_FileName;
 };
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
@@ -192,7 +192,7 @@ void reversibility::SetFileSize(uint64_t Value)
 }
 
 //---------------------------------------------------------------------------
-uint64_t reversibility::GetFileSize() const
+uint64_t reversibility::FileSize() const
 {
     return FileSize_.Data(Pos_);
 }
@@ -240,14 +240,17 @@ void reversibility::data::SetData(size_t Pos, buffer&& Buffer, bool AddMask)
                 NewMaxCount *= 4;
             auto NewSizeInBytes = NewMaxCount * sizeof(std::remove_pointer<decltype(Content_)>::type);
             auto NewContent = (decltype(Content_))new uint8_t[NewSizeInBytes];
+            size_t OldSizeInBytes;
             if (Content_)
             {
-                auto OldSizeInBytes = MaxCount_ * sizeof(std::remove_pointer<decltype(Content_)>::type);
+                OldSizeInBytes = MaxCount_ * sizeof(std::remove_pointer<decltype(Content_)>::type);
                 NewSizeInBytes -= OldSizeInBytes;
                 memcpy((uint8_t*)NewContent, Content_, OldSizeInBytes);
-                memset((uint8_t*)NewContent + OldSizeInBytes, 0, NewSizeInBytes);
-                delete[] (uint8_t*)Content_;
+                delete[](uint8_t*)Content_;
             }
+            else
+                OldSizeInBytes = 0;
+            memset((uint8_t*)NewContent + OldSizeInBytes, 0, NewSizeInBytes);
             Content_ = NewContent;
             MaxCount_ = NewMaxCount;
         }

--- a/Source/Lib/Compressed/RAWcooked/Reversibility.h
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.h
@@ -46,7 +46,7 @@ public:
     size_t                      Count() const;
     size_t                      RemainingCount() const;
     size_t                      ExtraCount() const;
-    uint64_t                    GetFileSize() const;
+    uint64_t                    FileSize() const;
 
 private:
     struct data

--- a/Source/Lib/Config.h
+++ b/Source/Lib/Config.h
@@ -62,5 +62,5 @@ enum class endianness : bool
 
 //---------------------------------------------------------------------------
 // Enums
-#define ENUM_BEGIN(_NAME) static const size_t __##_NAME##_line = __LINE__; enum class _NAME {
+#define ENUM_BEGIN(_NAME) static const size_t __##_NAME##_line = __LINE__; enum class _NAME : uint8_t {
 #define ENUM_END(_NAME) }; static const size_t _NAME##_Max = __LINE__ - __##_NAME##_line - 1;


### PR DESCRIPTION
@digitensions @stephenmcconnachie this patch will also reduce the RAM usage during 1st pass (creation of the intermediate RAWcooked reversibility file) in your use case of 64 KB padding per file and/or non-zero data in the DPX padding bits, due to a memory leak fixed.
But you'll get RAM usage issue again during the `--check` part (@bturkus the option is still only in dev snapshots but already a lot tested ;-) ) because all is still uncompressed in RAM before the decoding, this issue will be fixed in next PR.