### PR TITLE
Read RAWcooked reversibility metadata directly from the mapped file

### DIFF
--- a/Source/Lib/Compressed/RAWcooked/Reversibility.h
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.h
@@ -26,19 +26,20 @@ public:
     ENUM_END(element)
 
     // Actions - Storing
+    void                        SetBaseData(const uint8_t* BaseData);
     void                        SetUnique();
     void                        NewFrame();
-    void                        SetDataMask(element Element, buffer&& Buffer);
-    void                        SetData(element Element, buffer&& Buffer, bool AddMask);
+    void                        SetDataMask(element Element, const buffer_view& Buffer);
+    void                        SetData(element Element, size_t Offset, size_t Size, bool AddMask);
     void                        SetFileSize(uint64_t Value);
 
     // Actions - Parsing
-    void                        StartParsing();
+    void                        StartParsing(const uint8_t* BaseData);
     void                        NextFrame();
 
     // Data
-    buffer_view                 Data(element Element) const;
-    buffer_view                 Data(element Element, size_t Pos) const;
+    buffer                      Data(element Element) const;
+    buffer                      Data(element Element, size_t Pos) const;
 
     // Info
     bool                        Unique() const;
@@ -54,18 +55,21 @@ private:
         ~data();
 
         // Set
-        void                    SetDataMask(buffer&& Buffer);
-        void                    SetData(size_t Pos, buffer&& Buffer, bool AddMask);
+        void                    SetDataMask(const buffer_view& Buffer);
+        void                    SetData(size_t Pos, size_t Offset, size_t Size, bool AddMask);
 
         // Get
-        buffer_view             Data(size_t Pos) const;
-
-        // Options
-        void                    SanitizeFileName(size_t Pos);
+        buffer                  Data(const uint8_t* BaseData, size_t Pos) const;
 
     private:
         buffer                  Mask_;
-        buffer*                 Content_ = nullptr;
+        struct offset_size
+        {
+            size_t              Offset;
+            size_t              Size;
+            bool                AddMask;
+        };
+        offset_size*            Content_;
         size_t                  MaxCount_ = 0;
     };
     data                        Data_[element_Max];
@@ -88,6 +92,7 @@ private:
 
     size_t                      Pos_ = 0;
     size_t                      Count_ = 0;
+    const uint8_t*              BaseData_ = nullptr;
     bool                        Unique_ = false;
 };
 

--- a/Source/Lib/Compressed/RAWcooked/Track.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Track.cpp
@@ -17,14 +17,14 @@
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
-bool track_info::Init()
+bool track_info::Init(const uint8_t* BaseData)
 {
     if (RawFrame)
         return false; // Already done
     RawFrame = new raw_frame;
     RawFrame->FrameProcess = FrameWriter;
 
-    ReversibilityData->StartParsing();
+    ReversibilityData->StartParsing(BaseData);
     RawFrame->SetPre(ReversibilityData->Data(reversibility::element::BeforeData));
     RawFrame->SetPost(ReversibilityData->Data(reversibility::element::AfterData));
 

--- a/Source/Lib/Compressed/RAWcooked/Track.h
+++ b/Source/Lib/Compressed/RAWcooked/Track.h
@@ -61,7 +61,6 @@ enum class format_kind
 };
 
 //---------------------------------------------------------------------------
-void SanitizeFileName(buffer& FileName);
 format Format_FromCodecID(const char* Name);
 format_kind FormatKind(format Format);
 base_wrapper* CreateWrapper(format Format);
@@ -83,7 +82,7 @@ public:
 
     bool                        ParseDecodedFrame(input_base_uncompressed* Parser = nullptr);
 
-    bool                        Init();
+    bool                        Init(const uint8_t* BaseData);
     input_base_uncompressed*    InitOutput_Find();
     input_base_uncompressed*    InitOutput(input_base_uncompressed* PotentialParser, raw_frame::flavor Flavor);
     bool                        Process(const uint8_t* Data, size_t Size);


### PR DESCRIPTION
and uncompress only when needed.

Previously the RAWcooked reversibility file was fully read from the file and also fully uncompressed before doing the decoding, with this patch the RAWcooked reversibility file is scanned for getting only the byte offset of each frame related content then the frame related content is uncompressed just before decoding the frame.

This reduces the RAM pressure especially when there are several KB of padding per file and/or non-zero data in the DPX padding bits, now I don't expect more than stable ~100 MB or RAM uage due to FFV1 decoder state x the count of slices, cc @digitensions @stephenmcconnachie.

RAM usage could be even more reduced but less important now, lower priority.

