### PR TITLE
Avoid the risk of non-reversibilty with padded DPX

### DIFF
--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -73,7 +73,7 @@ man1_MANS = ../../../Source/CLI/rawcooked.1
 
 AM_TESTS_FD_REDIRECT = 9>&2
 
-TESTS = test/test1.sh test/test1b.sh test/test2.sh test/test3.sh test/reversibilityfile.sh test/check.sh test/legacy.sh test/multiple.sh test/valgrind.sh test/overwrite.sh test/increasingdigitcount.sh test/gaps.sh test/slices.sh test/notfound.sh test/version.sh
+TESTS = test/test1.sh test/test1b.sh test/test2.sh test/test3.sh test/reversibilityfile.sh test/paddingbits.sh test/check.sh test/legacy.sh test/multiple.sh test/valgrind.sh test/overwrite.sh test/increasingdigitcount.sh test/gaps.sh test/slices.sh test/notfound.sh test/version.sh
 
 TESTING_DIR = test/TestingFiles
 

--- a/Project/GNU/CLI/test/multiple.sh
+++ b/Project/GNU/CLI/test/multiple.sh
@@ -16,7 +16,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        run_rawcooked --file -d ${files}
+        run_rawcooked --no-check-padding --file -d ${files}
         if ! check_success "file rejected at input" "file accepted at input" ; then
             clean
             continue

--- a/Project/GNU/CLI/test/paddingbits.sh
+++ b/Project/GNU/CLI/test/paddingbits.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+script_path="${PWD}/test"
+. ${script_path}/helpers.sh
+
+while read line ; do
+    file="$(basename "$(echo "${line}" | cut -d' ' -f1)")"
+    path="$(dirname "$(echo "${line}" | cut -d' ' -f1)")"
+    filetomodify="$(echo "${line}" | cut -d' ' -f2)"
+    want="$(echo "${line}" | cut -d' ' -f3)"
+    options="$(echo "${line}" | cut -s -d' ' -f4-)"
+    test="${file} $filetomodify $options"
+
+    pushd "${files_path}/${path}" >/dev/null 2>&1
+        if [ "${filetomodify}" != "X" ] ; then
+          filenametomodify=$(ls ${file} | sed -n ${filetomodify}p)
+          chmod u+w ${file}/${filenametomodify} || echo "chmod issue"
+          truncate --size=-1 ${file}/${filenametomodify} || echo "truncate issue"
+          printf "\x5f" >> ${file}/${filenametomodify} || echo "printf issue"
+        fi
+        
+        run_rawcooked -y $options "${file}"
+
+        # check expected result
+        if [ "${want}" == "fail" ] ; then
+            if check_failure "file rejected at input" "file accepted at input" ; then
+                 echo "OK: ${test}, file rejected at input" >&${fd}
+            fi
+            continue
+        else
+            if check_success "file rejected at input" "file accepted at input" ; then
+               echo "OK: ${test}, file accepted at input" >&${fd}
+           fi
+        fi
+
+        clean
+    popd >/dev/null 2>&1
+done < "${script_path}/paddingbits.txt"
+
+exit ${status}
+

--- a/Project/GNU/CLI/test/paddingbits.txt
+++ b/Project/GNU/CLI/test/paddingbits.txt
@@ -1,0 +1,18 @@
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X fail 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check-padding
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --check-padding
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check-padding
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --no-check-padding 

--- a/Project/GNU/CLI/test/reversibilityfile.sh
+++ b/Project/GNU/CLI/test/reversibilityfile.sh
@@ -21,7 +21,7 @@ while read line ; do
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
         # check presence of reversibility data file with --display-command
-        run_rawcooked --file -d "${file}/"
+        run_rawcooked --no-check-padding --file -d "${file}/"
         check_success "file rejected at input" "file accepted at input"
 
         if [ ! -e "${file}.rawcooked_reversibility_data" ] ; then
@@ -33,7 +33,7 @@ while read line ; do
         mv -f "${file}.rawcooked_reversibility_data" "${file}.rawcooked_reversibility_data.save"
 
         # check if reversibility data file is cleaned when using internal encoder
-        run_rawcooked --file "${file}/"
+        run_rawcooked --no-check-padding --file "${file}/"
         check_success "file rejected at input" "file accepted at input"
         if [ -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, reversibility data file not cleaned after encoding" >&${fd}
@@ -43,7 +43,7 @@ while read line ; do
         fi
 
         # check if reversibility data file is cleaned with -n option and an existing mkv
-        run_rawcooked -n "${file}/"
+        run_rawcooked --no-check-padding -n "${file}/"
         if [ -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, reversibility data file not cleaned with -n option and an existing mkv" >&${fd}
             status=1
@@ -54,7 +54,7 @@ while read line ; do
 
         # check if stale reversibility data file is preserved with -n option
         cp -f "${file}.rawcooked_reversibility_data.save" "${file}.rawcooked_reversibility_data"
-        run_rawcooked -n "${file}/"
+        run_rawcooked --no-check-padding -n "${file}/"
         check_failure "file rejected due to -n option and stale reversibility data file" "file accepted despite -n option and stale reversibility data file"
         if [ ! -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, stale reversibility data file removed despite -n option" >&${fd}
@@ -65,7 +65,7 @@ while read line ; do
 
         # check for error with -y option and an read only stale reversibility data file
         chmod 0444 "${file}.rawcooked_reversibility_data"
-        run_rawcooked -y "${file}/"
+        run_rawcooked --no-check-padding -y "${file}/"
         check_failure "file rejected due to read only stale reversibility data file" "file accepted despite read only stale reversibility data file"
         if [ ! -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, read only stale reversibility data file removed" >&${fd}
@@ -76,7 +76,7 @@ while read line ; do
 
         # check for error with -y option and an stale reversibility data file with no rights
         chmod 0000 "${file}.rawcooked_reversibility_data"
-        run_rawcooked -y "${file}/"
+        run_rawcooked --no-check-padding -y "${file}/"
         check_failure "file rejected due to insufficient rights on stale reversibility data file" "file accepted despite insufficient rights on stale reversibility data file"
         if [ ! -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, reversibility data file removed despite insufficient rights" >&${fd}
@@ -87,7 +87,7 @@ while read line ; do
         chmod 0644 "${file}.rawcooked_reversibility_data"
 
         # check if stale reversibility data file is deleted with -y option
-        run_rawcooked -y "${file}/"
+        run_rawcooked --no-check-padding -y "${file}/"
         check_success "file rejected due to stale reversibility data file, despite -y" "file accepted with -y option and an stale reversibility data file"
         if [ -e "${file}.rawcooked_reversibility_data" ] ; then
             echo "NOK: ${test}/${file}, stale reversibility data file not removed despite -y option" >&${fd}

--- a/Project/GNU/CLI/test/test1.sh
+++ b/Project/GNU/CLI/test/test1.sh
@@ -16,7 +16,7 @@ while read line ; do
     fi
 
     pushd "${files_path}/${path}" >/dev/null 2>&1
-        run_rawcooked -y --conch --file -d "${file}"
+        run_rawcooked -y --conch --no-check-padding --file -d "${file}"
 
         # check expected result
         if [ "${want}" == "fail" ] ; then

--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -42,7 +42,7 @@ while read line ; do
         fi
 
         # run analysis
-        run_rawcooked -y --conch --file ${file_input}
+        run_rawcooked -y --conch --no-check-padding --file ${file_input}
         check_success "file rejected at input" "file accepted at input" || continue
 
         source_warnings=$(echo "${cmd_stderr}" | grep "Warning: ")

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -96,6 +96,7 @@ int global::SetCheck(const char* Value, int& i)
 int global::SetCheckPadding(bool Value)
 {
     Actions.set(Action_CheckPadding, Value);
+    Actions.set(Action_CheckPaddingOptionIsSet, true);
     return 0;
 }
 
@@ -153,7 +154,7 @@ int global::SetAll(bool Value)
 {
     if (int ReturnValue = SetCheck(Value))
         return ReturnValue;
-    if (int ReturnValue = SetCheckPadding(Value))
+    if (int ReturnValue = (Value && SetCheckPadding(Value))) // Never implicitely set no check padding
         return ReturnValue;
     if (int ReturnValue = SetAcceptGaps(Value))
         return ReturnValue;

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -113,7 +113,7 @@ ReturnValue Help(const char* Name)
     cout << "              Same as --check --check-padding --coherency --conch --encode" << endl;
     cout << "              --hash" << endl;
     cout << "       --none" << endl;
-    cout << "              Same as --no-check --no-check-padding --no-coherency --no-conch" << endl;
+    cout << "              Same as --no-check --no-coherency --no-conch" << endl;
     cout << "              --no-encode --no-hash" << endl;
     cout << endl;
     cout << "       --check" << endl;
@@ -130,12 +130,17 @@ ReturnValue Help(const char* Name)
     cout << "              Do costly (in terms of analysis duration or bytes read) checks." << endl;
     cout << "              It is slower but guaranties reversibility with e.g." << endl;
     cout << "              DPX files with non zero padding bits." << endl;
+    cout << "              This option is forced if non-zero padding bits are found in the" << endl;
+    cout << "              first image of a sequence." << endl;
     cout << "       --no-check-padding" << endl;
     cout << "              Don't do costly (in terms of analysis duration or bytes read)" << endl;
     cout << "              checks." << endl;
     cout << "              It is quicker but may lead to partial reversibility with" << endl;
     cout << "              non conform files." << endl;
-    cout << "              Is default (it may change in the future)" << endl;
+    cout << "              This option is ignored if non-zero padding bits are found in the" << endl;
+    cout << "              first image of a sequence." << endl;
+    cout << "              By default the program will stop if --check is not" << endl;
+    cout << "              used at the same time (it may change in the future)." << endl;
     cout << endl;
     cout << "       --coherency" << endl;
     cout << "              Coherency check of the package." << endl;

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -95,7 +95,7 @@ Assume \fIno\fR as answer to all prompts, and run non-interactively.
 Same as --check --check-padding --coherency --conch --encode --hash (see below)
 .TP
 .B --none
-Same as --no-check --no-check-padding --no-coherency --no-conch --no-encode (see below)
+Same as --no-check --no-coherency --no-conch --no-encode (see below)
 .TP
 .B --check
 Check that the encoded file can be correctly decoded.
@@ -113,13 +113,17 @@ This is the default, but may change in the future.
 Run padding checks. Be aware check function can be demanding of time and processor usage.
 .br
 It is a slower process but guarantees reversibility, for example with DPX files that have bits with no zero padding.
+.br
+This option is forced if non-zero padding bits are found in the first image of a sequence.
 .TP
 .B --no-check-padding
 Do not run padding checks, as they are demanding of time and processor usage.
 .br
 This method is quicker, but be aware it may lead to partial reversibility with files that do no conform.
 .br
-This is default, but may change in the future.
+This option is ignored if non-zero padding bits are found in the first image of a sequence.
+.br
+By default the program will stop if --check is not used at the same time, but may change in the future.
 .TP
 .B --coherency
 Checks that the package and contents are coherent.

--- a/Source/Lib/Uncompressed/DPX/DPX.cpp
+++ b/Source/Lib/Uncompressed/DPX/DPX.cpp
@@ -445,7 +445,7 @@ void dpx::ParseBuffer()
     size_t In_Size = 0;
     if (IsSupported() && !Actions[Action_AcceptTruncated] && Actions[Action_CheckPadding])
     {
-        if ((Info.BitDepth == 10 || Info.BitDepth == 12) && Info.Packing == packing::MethodA)
+        if (MayHavePaddingBits())
         {
             size_t Step = Info.BitDepth == 10 ? 4 : 2;
             bool IsNOK = false;
@@ -550,6 +550,18 @@ void dpx::ConformanceCheck()
         HeaderCopy_Info--;
         HeaderCopy_Info |= (HasEncoding ? 1 : 0) << 12;
     }
+}
+
+//---------------------------------------------------------------------------
+bool dpx::MayHavePaddingBits()
+{
+    if ((flavor)Flavor == (flavor)-1)
+        return false;
+
+    auto Flavor_BitDepth = DPX_Tested[(size_t)Flavor].BitDepth;
+    auto Flavor_Packing = DPX_Tested[(size_t)Flavor].Packing;
+
+    return (Flavor_BitDepth == 10 || Flavor_BitDepth == 12) && Flavor_Packing == packing::MethodA;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Uncompressed/DPX/DPX.h
+++ b/Source/Lib/Uncompressed/DPX/DPX.h
@@ -54,6 +54,9 @@ public:
         Raw_RGBA_16_BE,
     ENUM_END(flavor)
 
+    // Features
+    bool                        MayHavePaddingBits();
+
     // Info about flavors
     static size_t               BytesPerBlock(flavor Flavor);
     static size_t               PixelsPerBlock(flavor Flavor); // Need no overlap every x pixels

--- a/Source/Lib/Utils/FileIO/Input_Base.h
+++ b/Source/Lib/Utils/FileIO/Input_Base.h
@@ -28,6 +28,7 @@ enum action : uint8_t
     Action_Coherency,
     Action_Conch,
     Action_CheckPadding,
+    Action_CheckPaddingOptionIsSet,
     Action_AcceptGaps,
     Action_AcceptTruncated,
     Action_Max
@@ -144,6 +145,9 @@ public:
     // Common info
     bool                        IsSequence;
     rawcooked*                  RAWcooked = nullptr;
+
+    // Features
+    virtual bool                MayHavePaddingBits() { return false; }
 };
 
 class input_base_uncompressed : public input_base, public uncompressed


### PR DESCRIPTION
Previously there was a risk of non-reversibility in the case of 10- and 12-bit "Filled A" DPX, FFmpeg ignoring the padding bits and RAWcooked not catching them for performance reasons (not fully reading each file 1 more time before encoding, knowing that non-zero padding bits are very rare).

In order to avoid the risk, default behavior is changed, in case of 10- and 12-bit "Filled A" DPX the behavior if `--check-padding` is not used is now:
check the first frame;
if non-zero content is found in the padding bits, switch to handling of padding bits for all frames with an informational message,
else if ` --check` is used, just an informational message indicating that there is a risk of failure of the check if there is a non-zero padding bit somewhere,
else if  ` --check --no-check-padding`, no informational message (but risk still exists of the failure of the check if there is a non-zero padding bit somewhere)
else if  ` --no-check-padding` alone, we consider that the user is aware of the risk and prefers performance over padding bits reversibility,

@digitensions @stephenmcconnachie in one of your use cases it will avoid the need to encode a first time then fails due to non-zero padding bits before relaunching with ` --check-padding` (and you can use ` --check --no-check-padding` instead of  ` --check` in your script if you don't want the informational message), with no performance impact, the need of re-encoding will be only if there are non-zero padding bits in one of the frames but the first one.
