### PR TITLE
Fix DPX non-zero padding bits check related memory leak

### DIFF
--- a/Source/Lib/Uncompressed/DPX/DPX.cpp
+++ b/Source/Lib/Uncompressed/DPX/DPX.cpp
@@ -485,6 +485,9 @@ void dpx::ParseBuffer()
         RAWcooked->Parse();
     }
 
+    // Clean up
+    delete[] In;
+
     if (Actions[Action_Conch])
         ConformanceCheck();
 }


### PR DESCRIPTION
@digitensions @stephenmcconnachie sorry there was another memory leak I missed when there is a lot of non-zero padding bits.