### PR TITLE
Optimize memory allocation during reversibility file creation 

### DIFF
--- a/Source/Lib/Compressed/RAWcooked/RAWcooked.h
+++ b/Source/Lib/Compressed/RAWcooked/RAWcooked.h
@@ -24,16 +24,16 @@ public:
                                 rawcooked();
                                 ~rawcooked();
 
-    bool                        Unique; // If set, data is for the whole stream (unique file)
+    bool                        Unique = false; // If set, data is for the whole stream (unique file)
 
-    const uint8_t*              BeforeData;
-    uint64_t                    BeforeData_Size;
+    const uint8_t*              BeforeData = nullptr;
+    uint64_t                    BeforeData_Size = 0;
 
-    const uint8_t*              AfterData;
-    uint64_t                    AfterData_Size;
+    const uint8_t*              AfterData = nullptr;
+    uint64_t                    AfterData_Size = 0;
 
-    const uint8_t*              InData;
-    uint64_t                    InData_Size;
+    const uint8_t*              InData = nullptr;
+    uint64_t                    InData_Size = 0;
 
     md5*                        HashValue = nullptr;
     bool                        IsAttachment = false;
@@ -42,16 +42,12 @@ public:
     void                        ResetTrack();
 
     string                      OutputFileName;
-    uint64_t                    FileSize;
+    uint64_t                    FileSize = 0;
 
 private:
-    // File IO
-    size_t                      BlockCount;
-
-    // First frame info
-    buffer                      FirstFrame_Before;
-    buffer                      FirstFrame_After;
-    buffer                      FirstFrame_FileName;
+    // Private
+    class private_data;
+    private_data* const          Data_;
 };
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
@@ -98,6 +98,11 @@ static bool Uncompress(const buffer_view& In, buffer& Out)
     // Size in EBML style
     auto Data = In.Data();
     auto Size = In.Size();
+    if (!Size)
+    {
+        Out.Clear();
+        return false;
+    }
     decltype(Size) Offset = 0;
     uint64_t UncompressedSize = Data[0];
     if (!UncompressedSize)

--- a/Source/Lib/Uncompressed/DPX/DPX.h
+++ b/Source/Lib/Uncompressed/DPX/DPX.h
@@ -72,6 +72,9 @@ private:
     // Comparison
     uint8_t*                    HeaderCopy = NULL;
     uint64_t                    HeaderCopy_Info; // 0-11: buffer size - 1, 12: ignore offsets to data image 
+
+    // Temp
+    buffer                      In;
 };
 
 string DPX_Flavor_String(uint8_t Flavor);


### PR DESCRIPTION
Just some internal refactoring in order to avoid to keep asking the OS for allocation and release of memory, with this PR memory allocation for the first analyzed file is kept during the parsing of other filess.