### PR TITLE
Use light version of the test files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ build:
 
 before_test:
 - ps: |
-    git clone https://github.com/MediaArea/RAWCooked-RegressionTestingFiles.git Project/GNU/CLI/test/TestingFiles
+    git clone https://github.com/MediaArea/RAWCooked-RegressionTestingFiles-Light.git Project/GNU/CLI/test/TestingFiles
     Invoke-WebRequest https://www.mediaarea.net/download/snapshots/binary/ffmpeg/latest/FFmpeg_Bin_Latest_Windows_Static_x64.zip -OutFile FFmpeg_Bin_Latest_Windows_Static_x64.zip
     Expand-Archive FFmpeg_Bin_Latest_Windows_Static_x64.zip -DestinationPath .
     Copy-Item bin/ffmpeg.exe -Destination Project/GNU/CLI/ffmpeg

--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -80,4 +80,4 @@ TESTING_DIR = test/TestingFiles
 clone_testing_files: $(TESTING_DIR)
 
 $(TESTING_DIR):
-	git clone https://github.com/MediaArea/RAWCooked-RegressionTestingFiles.git test/TestingFiles
+	git clone https://github.com/MediaArea/RAWCooked-RegressionTestingFiles-Light.git test/TestingFiles

--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -36,7 +36,7 @@ files_path="${PWD}/test/TestingFiles"
 
 status=0
 
-timeout=480
+timeout=30
 
 fatal() {
     local test="${1}"

--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -62,7 +62,6 @@ Formats/DPX/Flavors/RGBA_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_a
 Formats/DPX/Flavors/RGBA_16_FilledA_BE/uncropped_DPX_4K_16bit_Overscan15pros.CutFrom3640to128Height.dpx pass
 Formats/DPX/Flavors/RGBA_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_alpha.dpx pass
 Formats/DPX/Flavors/RGBA_16_Packed_BE/16bit_a.dpx pass
-Formats/DPX/Flavors/RGBA_16_Packed_BE/16bit_a.2.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_BE/8bit.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_BE/checkerboard_1080p_nuke_bigendian_8bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_8_Packed_LE/checkerboard_1080p_nuke_littleendian_8bit_noalpha.dpx pass


### PR DESCRIPTION
I created a lightweight version of the test files, with most of the image content discarded, in order to reduce the load of the CI, hoping that there will be less CI checks stalled.
I still get stall from Travis macOS, but it seems that it is less than usual, and jobs time is reduced by 3 minutes (7 vs 10 minutes for Linux, 10 vs 13 minutes for macOS).
Let's try...