### PR TITLE
Prevent files not readable by FFmpeg

### DIFF
--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -113,7 +113,19 @@ bool parse_info::ParseFile_Input(input_base& SingleFile, bool OverrideCheckPaddi
         IsDetected = true;
 
     if (Global.Errors.HasErrors())
+    {
+        if (strstr(Global.Errors.ErrorMessage(), "becoming too big"))
+        {
+            Global.ProgressIndicator_Stop();
+            cerr << "Error: the reversibility file is becoming unexpectedly big.\n"
+                    "       FFmpeg, used for muxing the output, has some issues with big\n"
+                    "       attachments, and such big reversibility file is not expected\n"
+                    "       with such compression, we prefer to be safe and we reject the\n"
+                    "       compression.\n"
+                    "       Please contact info@mediaarea.net if you want support of such input." << endl;
+        }
         return true;
+    }
     return false;
 }
 

--- a/Source/Lib/Compressed/RAWcooked/IntermediateWrite.cpp
+++ b/Source/Lib/Compressed/RAWcooked/IntermediateWrite.cpp
@@ -24,6 +24,7 @@ static const char* MessageText[] =
     "file already exists",
     "cannot write to the file",
     "cannot remove file",
+    "file is becoming too big",
 };
 
 enum code : uint8_t
@@ -33,6 +34,7 @@ enum code : uint8_t
     FileAlreadyExists,
     FileWrite,
     FileRemove,
+    FileBecomingTooBig,
     Max
 };
 
@@ -88,6 +90,15 @@ bool intermediate_write::Delete()
     }
 
     return false;
+}
+
+//---------------------------------------------------------------------------
+void intermediate_write::SetErrorFileBecomingTooBig()
+{
+    if (Errors)
+    {
+        Errors->Error(IO_IntermediateWriter, error::type::Undecodable, (error::generic::code)intermediatewrite_issue::undecodable::FileBecomingTooBig, FileName);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Compressed/RAWcooked/IntermediateWrite.h
+++ b/Source/Lib/Compressed/RAWcooked/IntermediateWrite.h
@@ -36,6 +36,7 @@ public:
     bool*                       ProgressIndicator_IsPaused = nullptr;
     condition_variable*         ProgressIndicator_IsEnd = nullptr;
     errors*                     Errors = nullptr;
+    void                        SetErrorFileBecomingTooBig();
 
     // File IO
     void WriteToDisk(const uint8_t* Buffer, size_t Buffer_Size);

--- a/Source/Lib/Compressed/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/Compressed/RAWcooked/RAWcooked.cpp
@@ -383,6 +383,7 @@ public:
     void                        Parse(element Element, const buffer_base& Content, const buffer_base& Mask = buffer());
     const compressed_buffer&    Compressed(element Element);
     bool                        IsUsingMask(element Element);
+    long long                   TotalSize = 0;
 
     // Write
     ebml_writer                 Writer;
@@ -518,6 +519,13 @@ void rawcooked::Parse()
     // Write
     WriteToDisk(Writer.GetBuffer(), Writer.GetBufferSize());
     Data_->BlockCount++;
+
+    // Handle too big output files
+    Data_->TotalSize += Writer.GetBufferSize();
+    if (Data_->TotalSize > 0x10000000) // TODO: add an option for avoiding this hard coded value; this value is from FFmpeg (prevent read by FFmpeg, with >= 0x40000000 older FFmpeg create invalid files)
+    {
+        SetErrorFileBecomingTooBig();
+    }
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Attachments with a size > 256 MiB are not demuxable by FFmpeg due to a code from FFmpeg considering such file as potentially corrupted, so we block the creation of such attachment.
For reference attachments with a size >= 1 GiB are not correctly muxed by some old FFmpeg, which is even worse.

Right now the creation of such RAWcooked reversibility file is blocked, a future patch will offer the possibility to use another method for storing RAWcooked reversibility file in MKV.