### PR TITLE
Handle -threads option also for decoding

### DIFF
--- a/.github/workflows/RAWcoocked_Checks.yml
+++ b/.github/workflows/RAWcoocked_Checks.yml
@@ -18,9 +18,11 @@ jobs:
       - name: OS packets
         run: | 
           if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
             sudo apt-get install -y valgrind
           fi
           if [ "$RUNNER_OS" == "macOS" ]; then
+            brew update
             brew install automake truncate
           fi
       - name: FFmpeg

--- a/Project/GNU/CLI/test/framerate.sh
+++ b/Project/GNU/CLI/test/framerate.sh
@@ -21,9 +21,9 @@ while read line ; do
         run_rawcooked -framerate ${rate} --no-check-padding --file "${file}"
         check_success "file rejected at input" "file accepted at input"
 
-        framerate=$(ffmpeg -hide_banner -i "${file}.mkv" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Video:.\+,' | cut -d, -f5)
+        framerate=$(ffmpeg -hide_banner -i "${file}.mkv" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Video:.\+,' | sed -En 's/.*,([0-9]+)fps,.*/\1/p')
 
-        if [ "${framerate}" != "${rate}fps" ] ; then
+        if [ "${framerate}" != "${rate}" ] ; then
             echo "NOK: ${test}/${file}, wrong output framerate, requested: ${rate}, got: ${framerate}" >&${fd}
             status=1
         fi

--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -170,7 +170,7 @@ run_rawcooked() {
     fi >/dev/null 2>&1
 
     if test -z "${WSL}" ; then
-        ${valgrind} rawcooked $@ >"${temp}/stdout" 2>"${temp}/stderr" & kill -STOP ${!}; local pid=${!}
+        ${valgrind} rawcooked -threads 1 $@ >"${temp}/stdout" 2>"${temp}/stderr" & kill -STOP ${!}; local pid=${!}
         sleep ${timeout} && (kill -HUP ${pid} ; fatal "command timeout: rawcooked $@") & local watcher=${!}
         kill -CONT ${pid} ; wait ${pid}
         cmd_status="${?}"

--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -107,41 +107,6 @@ check_failure() {
     return ${local_status}
 }
 
-check_framemd5() {
-    local raw="${1}"
-    local mkv="${2}"
-    local local_status=0
-
-    local media=$(ffmpeg -hide_banner -i "${raw}" 2>&1 </dev/null | tr -d ' ' | grep -m1 '^Stream#.\+:.\+' | cut -d ':' -f 3)
-    if [ "${media}" == "Video" ] ; then
-        pixfmt=$(ffmpeg -hide_banner -i "${raw}" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Video:.\+,' | cut -d, -f2)
-        ffmpeg -i "${raw}" -f framemd5 "${raw}.framemd5" </dev/null >/dev/null 2>&1
-        ffmpeg -i "${mkv}" -pix_fmt ${pixfmt} -f framemd5 "${mkv}.framemd5" </dev/null >/dev/null 2>&1
-    elif [ "${media}" == "Audio" ] ; then
-        pcmfmt=$(ffmpeg -hide_banner -i "${raw}" 2>&1 </dev/null | tr -d ' ' | grep -m1 'Stream#.\+:.\+:Audio:' | grep -o 'pcm_[[:alnum:]]\+')
-        ffmpeg -i "${raw}" -c:a ${pcmfmt} -f framemd5 "${raw}.framemd5" </dev/null >/dev/null 2>&1
-        ffmpeg -i "${mkv}" -c:a ${pcmfmt} -f framemd5 "${mkv}.framemd5" </dev/null >/dev/null 2>&1
-    else
-        echo "NOK: ${test}/${file}, stream format not recognized" >&${fd}
-        rm -f "${raw}.framemd5" "${mkv}.framemd5"
-        status=1
-        local_status=1
-        return ${local_status}
-    fi
-
-    framemd5_a="$(grep -m1 -o '[0-9a-f]\{32\}' "${raw}.framemd5")"
-    framemd5_b="$(grep -m1 -o '[0-9a-f]\{32\}' "${mkv}.framemd5")"
-    rm -f "${raw}.framemd5" "${mkv}.framemd5"
-
-    if [ -z "${framemd5_a}" ] || [ -z "${framemd5_b}" ] || [ "${framemd5_a}" != "${framemd5_b}" ] ; then
-        echo "NOK: ${test}/${file}, framemd5 mismatch" >&${fd}
-        status=1
-        local_status=1
-    fi
-
-    return ${local_status}
-}
-
 check_files() {
     local original="${1}"
     local decoded="${2}"

--- a/Project/GNU/CLI/test/test1.sh
+++ b/Project/GNU/CLI/test/test1.sh
@@ -46,12 +46,6 @@ while read line ; do
             continue
         fi
 
-        # check framemd5
-        if ! check_framemd5 "${file}" "${file}.mkv" ; then
-            clean
-            continue
-        fi
-
         # check decoding
         run_rawcooked --conch "${file}.mkv"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then

--- a/Project/GNU/CLI/test/test1b.sh
+++ b/Project/GNU/CLI/test/test1b.sh
@@ -48,12 +48,6 @@ while read line ; do
             continue
         fi
 
-        # check framemd5
-        if ! check_framemd5 "${file}" "${file}.mkv" ; then
-            clean
-            continue
-        fi
-
         # check decoding
         run_rawcooked --conch "${file}.mkv"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then

--- a/Source/Lib/CoDec/FFV1/FFV1_Frame.h
+++ b/Source/Lib/CoDec/FFV1/FFV1_Frame.h
@@ -24,7 +24,7 @@ class ffv1_frame
 {
 public:
     // Constructor/Destructor
-    ffv1_frame();
+    ffv1_frame(ThreadPool* Pool);
     ~ffv1_frame();
 
     // External metadata

--- a/Source/Lib/Compressed/Matroska/Matroska.h
+++ b/Source/Lib/Compressed/Matroska/Matroska.h
@@ -41,7 +41,7 @@ class frame_writer;
 class matroska : public input_base
 {
 public:
-    matroska(const string& OutputDirectoryName, user_mode* Mode, ask_callback Ask_Callback, errors* Errors = nullptr);
+    matroska(const string& OutputDirectoryName, user_mode* Mode, ask_callback Ask_Callback, ThreadPool* Pool, errors* Errors = nullptr);
     ~matroska();
 
     void                        Shutdown();

--- a/Source/Lib/Compressed/RAWcooked/Track.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Track.cpp
@@ -34,7 +34,7 @@ bool track_info::Init(const uint8_t* BaseData)
 
     if (!Wrapper)
     {
-        Wrapper = CreateWrapper(Format);
+        Wrapper = CreateWrapper(Format, Pool);
         if (!Wrapper)
             return true;
     }
@@ -139,7 +139,7 @@ bool track_info::OutOfBand(const uint8_t* Data, size_t Size)
     // Parse
     if (!Wrapper)
     {
-        Wrapper = CreateWrapper(Format);
+        Wrapper = CreateWrapper(Format, Pool);
         if (!Wrapper)
             return true;
     }
@@ -258,10 +258,11 @@ void track_info::End(size_t i)
 
 //---------------------------------------------------------------------------
 //
-track_info::track_info(const frame_writer& FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors) :
+track_info::track_info(const frame_writer& FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors, ThreadPool* Pool_) :
     input_base(Errors, Parser_ReversibilityData),
     ReversibilityData(new reversibility()),
-    FrameWriter(new frame_writer(FrameWriter_Source))
+    FrameWriter(new frame_writer(FrameWriter_Source)),
+    Pool(Pool_)
 {
     input_base::Actions = Actions;
 }

--- a/Source/Lib/Compressed/RAWcooked/Track.h
+++ b/Source/Lib/Compressed/RAWcooked/Track.h
@@ -63,7 +63,7 @@ enum class format_kind
 //---------------------------------------------------------------------------
 format Format_FromCodecID(const char* Name);
 format_kind FormatKind(format Format);
-base_wrapper* CreateWrapper(format Format);
+base_wrapper* CreateWrapper(format Format, ThreadPool* Pool);
 class reversibility;
 
 //---------------------------------------------------------------------------
@@ -73,9 +73,9 @@ class track_info : public input_base
 public:
     reversibility*         ReversibilityData = nullptr;
 
-    track_info(const frame_writer& FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors);
-    track_info(const frame_writer* FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors) :
-        track_info(*FrameWriter_Source, Actions, Errors)
+    track_info(const frame_writer& FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors, ThreadPool* Pool);
+    track_info(const frame_writer* FrameWriter_Source, const bitset<Action_Max>& Actions, errors* Errors, ThreadPool* Pool) :
+        track_info(*FrameWriter_Source, Actions, Errors, Pool)
     {
     }
     ~track_info();
@@ -94,6 +94,7 @@ public:
     void                        SetHeight(uint32_t NewHeight) { Height = NewHeight; }
 
 private:
+    ThreadPool*                 Pool = nullptr;
     frame_writer*               FrameWriter = nullptr;
     input_base_uncompressed*    DecodedFrameParser = nullptr;
     base_wrapper*               Wrapper = nullptr;


### PR DESCRIPTION
Reuse FFmpeg option `-threads` also for decoding.
And limit decoder thread count to the hardware concurrency if no option provided.

Also configure the tests to mono-thread as it seems that VM used for Travis CI and also GitHub Actions have some random time outs when threads are used (impossible to reproduce outside their VM environments).
Note: in practice, removing threads in GitHub Actions seems to speed up the tests...