### PR TITLE
Update of integrated output file hash check 

### DIFF
--- a/Project/GNU/CLI/test/paddingbits.txt
+++ b/Project/GNU/CLI/test/paddingbits.txt
@@ -2,19 +2,26 @@ Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X fail
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check-padding
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --hash
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --all
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --no-check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV X pass --check --no-check-padding --quick-check-padding   
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --check-padding
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check --hash
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 pass --all
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 2 fail --check --no-check-padding --quick-check-padding  
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check-padding
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --hash
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --check-padding 
+Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --all
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 fail --check --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --no-check-padding --quick-check-padding 

--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -57,7 +57,7 @@ while read line ; do
         # check decoding
         run_rawcooked --check "${file}.mkv"
         check_success "decoding check failed" "decoding checked"
-        if ! contains "Reversability was checked, no issue detected." "${cmd_stdout}" ; then
+        if ! contains "Decoding was checked, no issue detected." "${cmd_stdout}" ; then
             echo "NOK: ${test}, wrong decoding check output, ${cmd_stdout}" >&${fd}
             status=1
             clean

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -66,7 +66,7 @@ int global::SetAcceptFiles()
 //---------------------------------------------------------------------------
 int global::SetCheck(bool Value)
 {
-    Check = Value;
+    Actions.set(Action_Check, Value);
     return 0;
 }
 
@@ -88,7 +88,7 @@ int global::SetCheck(const char* Value, int& i)
         return 0;
     }
 
-    Check = true;
+    Actions.set(Action_Check);
     return 0;
 }
 
@@ -139,7 +139,7 @@ int global::SetEncode(bool Value)
 //---------------------------------------------------------------------------
 int global::SetFrameMd5(bool Value)
 {
-    FrameMd5 = Value;
+    Actions.set(Action_FrameMd5, Value);
     return 0;
 }
 
@@ -383,8 +383,6 @@ int global::ManageCommandLine(const char* argv[], int argc)
     AcceptFiles = false;
     OutputFileName_IsProvided = false;
     Quiet = false;
-    Check = false;
-    FrameMd5 = false;
     Actions.set(Action_Encode);
     Actions.set(Action_Coherency);
     Hashes = hashes(&Errors);

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -44,8 +44,6 @@ public:
     bool                        HasAtLeastOneFile;
     bool                        OutputFileName_IsProvided;
     bool                        Quiet;
-    bool                        Check;
-    bool                        FrameMd5;
     bitset<Action_Max>          Actions;
 
     // Intermediate info

--- a/Source/CLI/Input.cpp
+++ b/Source/CLI/Input.cpp
@@ -418,7 +418,7 @@ int input::AnalyzeInputs(global& Global)
         return 1;
     }
 
-    if (Global.Check && HasMoreThanOneFile)
+    if (Global.Actions[Action_Check] && HasMoreThanOneFile)
     {
         cerr << "Error: \" --check\" feature is implemented only for 1 input.\nPlease contact info@mediaarea.net if you want support of such input." << endl;
         return 1;

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -171,7 +171,7 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
         else if (SingleFile.MayHavePaddingBits() && !Global.Actions[Action_CheckPaddingOptionIsSet]) // If --no-checking-padding is not present
         {
             Global.ProgressIndicator_Stop();
-            if (Global.Check)
+            if (Global.Actions[Action_Check])
             {
                 cerr << "Info: data can contain non-zero padding bits, padding bits will be\n"
                         "      checked only during reversibility check so after encoding,\n"
@@ -362,7 +362,7 @@ int ParseFile_Compressed(parse_info& ParseInfo)
 
     // Matroska
     int ReturnValue = 0;
-    bool NoOutputCheck = Global.Check && !Global.OutputFileName_IsProvided;
+    bool NoOutputCheck = Global.Actions[Action_Check] && !Global.OutputFileName_IsProvided;
     if (!ParseInfo.IsDetected)
     {
         // Threads
@@ -385,8 +385,8 @@ int ParseFile_Compressed(parse_info& ParseInfo)
 
         matroska* M = new matroska(OutputDirectoryName, &Global.Mode, Ask_Callback, Thread_Pool, &Global.Errors);
         M->Quiet = Global.Quiet;
-        M->NoWrite = Global.Check;
-        M->NoOutputCheck = NoOutputCheck;
+        M->NoWrite = Global.Actions[Action_Check];
+        M->NoOutputCheck = Global.Actions[Action_Check];
         if (NoOutputCheck)
             NoOutputCheck = M->Hashes_FromRAWcooked ? false : true; // If hashes are present in the file, output was checked by using hashes
         if (ParseInfo.ParseFile_Input(*M))
@@ -400,12 +400,12 @@ int ParseFile_Compressed(parse_info& ParseInfo)
     // End
     if (ParseInfo.IsDetected && !Global.Quiet)
     {
-        if (!Global.Check)
+        if (!Global.Actions[Action_Check])
             cout << "\nFiles are in " << OutputDirectoryName << '.' << endl;
         else if (!Global.Errors.HasErrors())
             cout << '\n' << (NoOutputCheck ? "Decoding" : "Reversability") << " was checked, no issue detected." << endl;
     }
-    if (Global.Check && Global.Errors.HasErrors())
+    if (Global.Actions[Action_Check] && Global.Errors.HasErrors())
         cout << '\n' << (NoOutputCheck ? "Decoding" : "Reversability") << " was checked, issues detected, see below." << endl;
 
     return ReturnValue;
@@ -505,7 +505,7 @@ int main(int argc, const char* argv[])
             case AlwaysYes: break;
             default:
                 if ((!Value && Global.Actions[Action_Encode] && !Output.Streams.empty())
-                 || (Global.Check && !Global.Errors.HasErrors() && !Global.OutputFileName.empty() && !Output.Streams.empty()))
+                 || (Global.Actions[Action_Check] && !Global.Errors.HasErrors() && !Global.OutputFileName.empty() && !Output.Streams.empty()))
                 {
                     cerr << "Do you want to continue despite warnings? [y/N] ";
                     string Result;
@@ -525,7 +525,7 @@ int main(int argc, const char* argv[])
         RAWcooked.Delete();
 
     // Check result
-    if (Global.Check && !Global.Errors.HasErrors() && !Global.OutputFileName.empty() && !Output.Streams.empty())
+    if (Global.Actions[Action_Check] && !Global.Errors.HasErrors() && !Global.OutputFileName.empty() && !Output.Streams.empty())
     {
         parse_info ParseInfo;
         Value = ParseInfo.FileMap.Open_ReadMode(Global.OutputFileName);

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -322,7 +322,7 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
     Command += Global.OutputFileName;
     Command += '\"';
 
-    if (Global.FrameMd5)
+    if (Global.Actions[Action_FrameMd5])
     {
         if (Global.FrameMd5FileName.empty())
         {

--- a/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
@@ -238,7 +238,7 @@ buffer reversibility::Data(element Element) const
 buffer reversibility::Data(element Element, size_t Pos) const
 {
     const auto ElementS = (size_t)Element;
-    if (ElementS >= element_Max || Pos >= Count_)
+    if (ElementS >= element_Max)
         return buffer();
     const auto& Data = Data_[ElementS];
     return Data.Data(BaseData_, Pos);

--- a/Source/Lib/Uncompressed/HashSum/HashSum.cpp
+++ b/Source/Lib/Uncompressed/HashSum/HashSum.cpp
@@ -140,7 +140,7 @@ void hashes::FromFile(string const& FileName, md5 const& MD5)
         if (find(HashFiles.begin(), HashFiles.end(), FileName) == HashFiles.end())
         {
             if (Errors)
-                Errors->Error(IO_Hashes, CheckFromFiles ? error::type::Undecodable : error::type::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileMissing : (error::generic::code)hashes_issue::invalid::FileHashMissing, FileName);
+                Errors->Error(IO_Hashes, WouldBeError ? error::type::Undecodable : error::type::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileMissing : (error::generic::code)hashes_issue::invalid::FileHashMissing, FileName);
         }
     }
     else
@@ -151,7 +151,7 @@ void hashes::FromFile(string const& FileName, md5 const& MD5)
             if (File->MD5 != MD5)
             {
                 if (Errors)
-                    Errors->Error(IO_Hashes, CheckFromFiles ? error::type::Undecodable : error::type::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileComparison : (error::generic::code)hashes_issue::invalid::FileHashComparison, FileName);
+                    Errors->Error(IO_Hashes, WouldBeError ? error::type::Undecodable : error::type::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileComparison : (error::generic::code)hashes_issue::invalid::FileHashComparison, FileName);
             }
         }
     }

--- a/Source/Lib/Uncompressed/HashSum/HashSum.h
+++ b/Source/Lib/Uncompressed/HashSum/HashSum.h
@@ -18,8 +18,7 @@
 class hashes
 {
 public:
-    hashes() {}
-    hashes(errors* Errors_Source) :
+    hashes(errors* Errors_Source = nullptr) :
         Errors(Errors_Source)
     {
     }

--- a/Source/Lib/Utils/FileIO/Input_Base.h
+++ b/Source/Lib/Utils/FileIO/Input_Base.h
@@ -31,6 +31,8 @@ enum action : uint8_t
     Action_CheckPaddingOptionIsSet,
     Action_AcceptGaps,
     Action_AcceptTruncated,
+    Action_Check,
+    Action_FrameMd5,
     Action_Max
 };
 


### PR DESCRIPTION
Update of https://github.com/MediaArea/RAWcooked/pull/206, especially relying on integrated hash when checking the MKV, avoiding to load again the source files.