### PR TITLE
Ability to disable hash check while checking the compressed file

### DIFF
--- a/Project/GNU/CLI/test/paddingbits.txt
+++ b/Project/GNU/CLI/test/paddingbits.txt
@@ -25,3 +25,83 @@ Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --check-padd
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --all
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 fail --check --no-check-padding 
 Features/AV_Package/818_DCDM_P3_IA_FIC_000918/818_OV 1 pass --check --no-check-padding --quick-check-padding 
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_FileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_NoHash.mkv X pass --check --no-hash
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --check
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --check
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --check
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --check
+Features/HashCheck/HashTest_FileHash.mkv X pass --check
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --check
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check
+Features/HashCheck/HashTest_NoHash.mkv X pass --check
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --check -n
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --check -n
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --check -n
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --check -n
+Features/HashCheck/HashTest_FileHash.mkv X pass --check -n
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check -n
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --check -n
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check -n
+Features/HashCheck/HashTest_NoHash.mkv X pass --check -n
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --check -y
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --check -y
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --check -y
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --check -y
+Features/HashCheck/HashTest_FileHash.mkv X pass --check -y
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check -y
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --check -y
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check -y
+Features/HashCheck/HashTest_NoHash.mkv X pass --check -y
+Features/HashCheck/HashTest_BuggyFileHash.mkv X fail --check --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --check --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --check --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --check --conch -n
+Features/HashCheck/HashTest_FileHash.mkv X pass --check --conch -n
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check --conch -n
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X fail --check --conch -n
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check --conch -n
+Features/HashCheck/HashTest_NoHash.mkv X pass --check --conch -n
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --check --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --check --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --check --conch -y
+Features/HashCheck/HashTest_FileHash.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_HashInternal.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_NoHash.mkv X pass --check --conch -y
+Features/HashCheck/HashTest_BuggyFileHash.mkv X fail --no-decode --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --no-decode --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --no-decode --conch -n
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --no-decode --conch -n
+Features/HashCheck/HashTest_FileHash.mkv X pass --no-decode --conch -n
+Features/HashCheck/HashTest_HashInternal.mkv X pass --no-decode --conch -n
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X fail --no-decode --conch -n
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --no-decode --conch -n
+Features/HashCheck/HashTest_NoHash.mkv X pass --no-decode --conch -n
+Features/HashCheck/HashTest_BuggyFileHash.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal.mkv X fail --no-decode --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal_BuggyFileHash.mkv X fail --no-decode --conch -y
+Features/HashCheck/HashTest_BuggyHashInternal_FileHash.mkv X fail --no-decode --conch -y
+Features/HashCheck/HashTest_FileHash.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_HashInternal.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_HashInternal_BuggyFileHash.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_HashInternal_FileHash.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_NoHash.mkv X pass --no-decode --conch -y
+Features/HashCheck/HashTest_BuggyFileHash_Dir X fail --all -n
+Features/HashCheck/HashTest_FileHash_Dir X pass --all -n
+Features/HashCheck/HashTest_BuggyFileHash_Dir X pass --all -y
+Features/HashCheck/HashTest_FileHash_Dir X pass --all -y
+Features/HashCheck/HashTest_BuggyFileHash_Dir X pass --all --no-conch -n
+Features/HashCheck/HashTest_FileHash_Dir X pass --all --no-conch -n
+Features/HashCheck/HashTest_BuggyFileHash_Dir X pass --all --no-conch -y
+Features/HashCheck/HashTest_FileHash_Dir X pass --all --no-conch -y

--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -139,6 +139,13 @@ int global::SetConch(bool Value)
 }
 
 //---------------------------------------------------------------------------
+int global::SetDecode(bool Value)
+{
+    Actions.set(Action_Decode, Value);
+    return 0;
+}
+
+//---------------------------------------------------------------------------
 int global::SetEncode(bool Value)
 {
     Actions.set(Action_Encode, Value);
@@ -163,6 +170,7 @@ int global::SetFrameMd5FileName(const char* FileName)
 int global::SetHash(bool Value)
 {
     Actions.set(Action_Hash, Value);
+    Actions.set(Action_HashOptionIsSet);
     return 0;
 }
 
@@ -178,6 +186,8 @@ int global::SetAll(bool Value)
     if (int ReturnValue = SetCoherency(Value))
         return ReturnValue;
     if (int ReturnValue = SetConch(Value))
+        return ReturnValue;
+    if (int ReturnValue = SetDecode(Value))
         return ReturnValue;
     if (int ReturnValue = SetEncode(Value))
         return ReturnValue;
@@ -329,6 +339,7 @@ int global::SetOption(const char* argv[], int& i, int argc)
     if (strcmp(argv[i], "-n") == 0)
     {
         OutputOptions["n"] = string();
+        OutputOptions.erase("y");
         Mode = AlwaysNo; // Also RAWcooked itself
         License.Feature(feature::GeneralOptions);
         return 0;
@@ -370,6 +381,7 @@ int global::SetOption(const char* argv[], int& i, int argc)
     if (strcmp(argv[i], "-y") == 0)
     {
         OutputOptions["y"] = string();
+        OutputOptions.erase("n");
         Mode = AlwaysYes; // Also RAWcooked itself
         License.Feature(feature::GeneralOptions);
         return 0;
@@ -393,6 +405,7 @@ int global::ManageCommandLine(const char* argv[], int argc)
     OutputFileName_IsProvided = false;
     Quiet = false;
     Actions.set(Action_Encode);
+    Actions.set(Action_Decode);
     Actions.set(Action_Coherency);
     Hashes = hashes(&Errors);
     ProgressIndicator_Thread = NULL;
@@ -486,6 +499,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
                 return Value;
             License.Feature(feature::GeneralOptions);
         }
+        else if (strcmp(argv[i], "--decode") == 0)
+        {
+            int Value = SetDecode(true);
+            if (Value)
+                return Value;
+        }
         else if (strcmp(argv[i], "--encode") == 0)
         {
             int Value = SetEncode(true);
@@ -553,6 +572,12 @@ int global::ManageCommandLine(const char* argv[], int argc)
         else if (strcmp(argv[i], "--no-conch") == 0)
         {
             int Value = SetConch(false);
+            if (Value)
+                return Value;
+        }
+        else if (strcmp(argv[i], "--no-decode") == 0)
+        {
+            int Value = SetDecode(false);
             if (Value)
                 return Value;
         }

--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -88,6 +88,7 @@ private:
     int SetAcceptGaps(bool Value);
     int SetCoherency(bool Value);
     int SetConch(bool Value);
+    int SetDecode(bool Value);
     int SetEncode(bool Value);
     int SetFrameMd5(bool Value);
     int SetFrameMd5FileName(const char* FileName);

--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -110,11 +110,11 @@ ReturnValue Help(const char* Name)
     cout << endl;
     cout << "ACTIONS" << endl;
     cout << "       --all" << endl;
-    cout << "              Same as --encode --hash --conch --coherency --check-padding" << endl;
-    cout << "              --check"<< endl;
+    cout << "              Same as --decode --encode --hash --conch --coherency" << endl;
+    cout << "               --check-padding --check"<< endl;
     cout << "       --none" << endl;
-    cout << "              Same as --no-encode --no-hash --no-conch --no-coherency" << endl;
-    cout << "              --quick-check" << endl;
+    cout << "              Same as --no-decode --no-encode --no-hash --no-conch" << endl;
+    cout << "               --no-coherency --quick-check" << endl;
     cout << endl;
     cout << "       --check" << endl;
     cout << "              Check that the encoded file can be correctly decoded." << endl;
@@ -162,6 +162,12 @@ ReturnValue Help(const char* Name)
     cout << "       --no-conch" << endl;
     cout << "              Don't do conformance check (see above)." << endl;
     cout << "              Is default (it may change in the future)" << endl;
+    cout << endl;
+    cout << "       --decode" << endl;
+    cout << "              Decode a compressed stream into audio-visual RAW data." << endl;
+    cout << "              Is default" << endl;
+    cout << "       --no-decode" << endl;
+    cout << "              Don't decode (see above)." << endl;
     cout << endl;
     cout << "       --encode" << endl;
     cout << "              Encode audio-visual RAW data into a compressed stream." << endl;

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -362,7 +362,7 @@ int ParseFile_Compressed(parse_info& ParseInfo)
 
     // Matroska
     int ReturnValue = 0;
-    bool NoOutputCheck = Global.Actions[Action_Check] && !Global.OutputFileName_IsProvided;
+    bool NoOutputCheck = (Global.Actions[Action_Check] || !Global.Actions[Action_Decode]) && !Global.OutputFileName_IsProvided;
     bool HasCheckedReversibility = !NoOutputCheck;
     if (!ParseInfo.IsDetected)
     {
@@ -386,8 +386,9 @@ int ParseFile_Compressed(parse_info& ParseInfo)
 
         matroska* M = new matroska(OutputDirectoryName, &Global.Mode, Ask_Callback, Thread_Pool, &Global.Errors);
         M->Quiet = Global.Quiet;
-        M->NoWrite = Global.Actions[Action_Check];
+        M->NoWrite = Global.Actions[Action_Check] || !Global.Actions[Action_Decode];
         M->NoOutputCheck = NoOutputCheck;
+        M->NoHashCheck = Global.Actions[Action_HashOptionIsSet] && !Global.Actions[Action_Hash];
         if (ParseInfo.ParseFile_Input(*M))
         {
             ReturnValue = 1;
@@ -401,9 +402,9 @@ int ParseFile_Compressed(parse_info& ParseInfo)
     // End
     if (ParseInfo.IsDetected && !Global.Quiet)
     {
-        if (!Global.Actions[Action_Check])
+        if (!Global.Actions[Action_Check] && Global.Actions[Action_Decode])
             cout << "\nFiles are in " << OutputDirectoryName << '.' << endl;
-        else if (!Global.Errors.HasErrors())
+        else if (Global.Actions[Action_Check] && !Global.Errors.HasErrors())
             cout << '\n' << (HasCheckedReversibility ? "Reversability" : "Decoding") << " was checked, no issue detected." << endl;
     }
     if (Global.Actions[Action_Check] && Global.Errors.HasErrors())
@@ -549,6 +550,7 @@ int main(int argc, const char* argv[])
 
             // Parse (check mode)
             Global.Actions.set(Action_QuickCheckAfterEncode, !Global.Actions[Action_Check]);
+            Global.Actions.set(Action_Decode, true); // Override config
             Value = ParseFile_Compressed(ParseInfo);
             if (!Value && !ParseInfo.IsDetected)
             {

--- a/Source/CLI/rawcooked.1
+++ b/Source/CLI/rawcooked.1
@@ -92,10 +92,10 @@ Assume \fIno\fR as answer to all prompts, and run non-interactively.
 .SS ACTIONS
 .TP
 .B --all
-Same as --encode --hash --conch --coherency --check-padding --check (see below)
+Same as --decode --encode --hash --conch --coherency --check-padding --check (see below)
 .TP
 .B --none
-Same as --no-encode --no-hash --no-conch --no-coherency --quick-check (see below)
+Same as --no-decode --no-encode --no-hash --no-conch --no-coherency --quick-check (see below)
 .TP
 .B --check
 Check that the encoded file can be correctly decoded.
@@ -152,6 +152,14 @@ This is currently partially implemented for DPX.
 Do not carry out conformance check (see above).
 .br
 This is default, but may change in the future.
+.TP
+.B --decode
+Encode a compressed stream into audio-visual RAW data.
+.br
+This is default.
+.TP
+.B --no-decode
+Do not carry out decode (see above).
 .TP
 .B --encode
 Encode audio-visual RAW data into a compressed stream.

--- a/Source/Lib/Compressed/Matroska/Matroska.h
+++ b/Source/Lib/Compressed/Matroska/Matroska.h
@@ -49,8 +49,9 @@ public:
     bool                        Quiet = false;
     bool                        NoWrite = false;
     bool                        NoOutputCheck = false;
-    hashes*                     Hashes_FromRAWcooked;
-    hashes*                     Hashes_FromAttachments;
+    bool                        NoHashCheck = false;
+    hashes*                     Hashes_FromRAWcooked = nullptr;
+    hashes*                     Hashes_FromAttachments = nullptr;
 
     // Theading relating functions
     void                        ProgressIndicator_Show();

--- a/Source/Lib/Uncompressed/HashSum/HashSum.cpp
+++ b/Source/Lib/Uncompressed/HashSum/HashSum.cpp
@@ -186,7 +186,7 @@ void hashes::Finish()
 
     for (auto HashItem : List_FromHashFiles)
     {
-        if (!HashItem.Flags[hashes::value::Flag_IsFound])
+        if (!HashItem.Flags[hashes::value::Flag_IsFound] && find(HashFiles.begin(), HashFiles.end(), HashItem.Name) == HashFiles.end())
         {
             if (Errors)
                 Errors->Error(IO_Hashes, CheckFromFiles ? error::type::Undecodable : error::type::Invalid, CheckFromFiles ? (error::generic::code)hashes_issue::undecodable::FileExtra : (error::generic::code)hashes_issue::invalid::FileHashExtra, HashItem.Name);
@@ -217,6 +217,8 @@ void hashsum::ParseBuffer()
     size_t PathSeparatorPos = HomePath.rfind('/');
     if (PathSeparatorPos != (size_t)-1 && PathSeparatorPos + 1 != HomePath.size())
         HomePath.resize(PathSeparatorPos + 1);
+    else
+        HomePath.clear();
 
     while (Buffer_Offset + 32 + 1 <= Buffer.Size())
     {

--- a/Source/Lib/Utils/FileIO/FileWriter.h
+++ b/Source/Lib/Utils/FileIO/FileWriter.h
@@ -57,6 +57,7 @@ public:
         IsNotEnd,
         NoWrite,
         NoOutputCheck,
+        NoHashCheck,
         mode_Max,
     };
     bitset<mode_Max>            Mode;

--- a/Source/Lib/Utils/FileIO/Input_Base.h
+++ b/Source/Lib/Utils/FileIO/Input_Base.h
@@ -24,7 +24,9 @@ class hashes;
 enum action : uint8_t
 {
     Action_Encode,
+    Action_Decode,
     Action_Hash,
+    Action_HashOptionIsSet,
     Action_Coherency,
     Action_Conch,
     Action_CheckPadding,


### PR DESCRIPTION
Make options more independent, internal hash check can be disable, conformance checker can be alone.
More coherent with the current help file.
Also add a bunch of tests about mix of options.