### PR TITLE
FFmpeg -nostdin only if -n or -y is set

### DIFF
--- a/Project/GNU/CLI/test/helpers.sh
+++ b/Project/GNU/CLI/test/helpers.sh
@@ -170,7 +170,7 @@ run_rawcooked() {
     fi >/dev/null 2>&1
 
     if test -z "${WSL}" ; then
-        ${valgrind} rawcooked -threads 1 $@ >"${temp}/stdout" 2>"${temp}/stderr" & kill -STOP ${!}; local pid=${!}
+        ${valgrind} rawcooked -n -threads 1 $@ >"${temp}/stdout" 2>"${temp}/stderr" & kill -STOP ${!}; local pid=${!}
         sleep ${timeout} && (kill -HUP ${pid} ; fatal "command timeout: rawcooked $@") & local watcher=${!}
         kill -CONT ${pid} ; wait ${pid}
         cmd_status="${?}"

--- a/Project/GNU/CLI/test/pcm.sh
+++ b/Project/GNU/CLI/test/pcm.sh
@@ -16,7 +16,7 @@ pushd "${files_path}" >/dev/null 2>&1
     check_success "check failed with one pcm" "check succeded with one pcm"
 
     # check decoding
-    run_rawcooked --conch "${file}.mkv"
+    run_rawcooked -y --conch "${file}.mkv"
     if ! check_success "mkv decoding failed" "mkv decoded" ; then
         clean
         continue

--- a/Project/GNU/CLI/test/test1.sh
+++ b/Project/GNU/CLI/test/test1.sh
@@ -47,7 +47,7 @@ while read line ; do
         fi
 
         # check decoding
-        run_rawcooked --conch "${file}.mkv"
+        run_rawcooked -y --conch "${file}.mkv"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then
             clean
             continue

--- a/Project/GNU/CLI/test/test1b.sh
+++ b/Project/GNU/CLI/test/test1b.sh
@@ -49,7 +49,7 @@ while read line ; do
         fi
 
         # check decoding
-        run_rawcooked --conch "${file}.mkv"
+        run_rawcooked -y --conch "${file}.mkv"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then
             clean
             continue

--- a/Project/GNU/CLI/test/test2.sh
+++ b/Project/GNU/CLI/test/test2.sh
@@ -73,7 +73,7 @@ while read line ; do
             continue
         fi
 
-        run_rawcooked --conch "${file}.mkv"
+        run_rawcooked -y --conch "${file}.mkv"
         check_success "mkv decoding failed" "mkv decoded"
         if ! check_success "mkv decoding failed" "mkv decoded" ; then
             clean

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -85,7 +85,8 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
         Command += Global.BinName;
 
     // Disable stdin for ffmpeg
-    Command += " -nostdin";
+    if (Global.OutputOptions.find("n") != Global.OutputOptions.end() && Global.OutputOptions.find("y") != Global.OutputOptions.end())
+        Command += " -nostdin";
 
     // Info
     bool Problem = false;


### PR DESCRIPTION
Update of https://github.com/MediaArea/RAWcooked/pull/215, adding `-nostdin` to FFmpeg only if no input is needed i.e. `-n` or `-y` is set.