### PR TITLE
Set the zlib compression to the lowest possible

### DIFF
--- a/Source/Lib/Compressed/RAWcooked/RAWcooked.cpp
+++ b/Source/Lib/Compressed/RAWcooked/RAWcooked.cpp
@@ -155,7 +155,7 @@ void compressed_buffer::Assign(const buffer_base& Content, const buffer_base& Ma
     auto destLen = UncompressedSize_;
     auto src = (const Bytef*)Temp;
     auto srcLen = (uLong)Content.Size();
-    if (compress(dest, &destLen, src, srcLen) < 0)
+    if (compress2(dest, &destLen, src, srcLen, 1) < 0)
     {
         // Uncompressed
         AssignBase(src, srcLen);


### PR DESCRIPTION
Compression is used on content mostly being 0, as it is a diff. zlib compression setting has no real impact on such content, but is very slow when the content is not compressable e.g. DPX 12-bit padding bit more or less random.