### PR TITLE
EXR 16-bit float support

### DIFF
--- a/Project/GNU/CLI/Makefile.am
+++ b/Project/GNU/CLI/Makefile.am
@@ -49,6 +49,7 @@ rawcooked_SOURCES = \
     ../../../Source/Lib/ThirdParty/zlib/zutil.c \
     ../../../Source/Lib/Uncompressed/AIFF/AIFF.cpp \
     ../../../Source/Lib/Uncompressed/DPX/DPX.cpp \
+    ../../../Source/Lib/Uncompressed/EXR/EXR.cpp \
     ../../../Source/Lib/Uncompressed/HashSum/HashSum.cpp \
     ../../../Source/Lib/Uncompressed/TIFF/TIFF.cpp \
     ../../../Source/Lib/Uncompressed/WAV/WAV.cpp \

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj
@@ -23,6 +23,7 @@
     <ClInclude Include="..\..\..\Source\Lib\Compressed\RAWcooked\Reversibility.h" />
     <ClInclude Include="..\..\..\Source\Lib\Compressed\RAWcooked\Track.h" />
     <ClInclude Include="..\..\..\Source\Lib\Uncompressed\AIFF\AIFF.h" />
+    <ClInclude Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.h" />
     <ClInclude Include="..\..\..\Source\Lib\Utils\BitStream\BitStream.h" />
     <ClInclude Include="..\..\..\Source\Lib\Config.h" />
     <ClInclude Include="..\..\..\Source\Lib\Utils\Buffer\Buffer.h" />
@@ -98,6 +99,7 @@
     <ClCompile Include="..\..\..\Source\Lib\Compressed\RAWcooked\Reversibility.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Compressed\RAWcooked\Track.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Uncompressed\AIFF\AIFF.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Utils\CRC32\ZenCRC32.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Uncompressed\DPX\DPX.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Utils\Errors\Errors.cpp" />

--- a/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2017/Lib/RAWcooked_Lib.vcxproj.filters
@@ -148,6 +148,12 @@
     <Filter Include="Header Files\Utils\Buffer">
       <UniqueIdentifier>{56157e64-cae9-4303-8afc-226380ab1406}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Uncompressed\EXR">
+      <UniqueIdentifier>{1c19204a-4553-4ffa-a28d-3845c589e947}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Uncompressed\EXR">
+      <UniqueIdentifier>{a2799b00-8701-4fd0-9657-36a4e798c82c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\Lib\Utils\BitStream\BitStream.h">
@@ -369,6 +375,9 @@
     <ClInclude Include="..\..\..\Source\Lib\CoDec\Wrapper.h">
       <Filter>Header Files\CoDec</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.h">
+      <Filter>Header Files\Uncompressed\EXR</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\Utils\CRC32\ZenCRC32.cpp">
@@ -523,6 +532,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\CoDec\Wrapper.cpp">
       <Filter>Source Files\CoDec</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.cpp">
+      <Filter>Source Files\Uncompressed\EXR</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj
+++ b/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj
@@ -23,6 +23,7 @@
     <ClInclude Include="..\..\..\Source\Lib\Compressed\RAWcooked\Reversibility.h" />
     <ClInclude Include="..\..\..\Source\Lib\Compressed\RAWcooked\Track.h" />
     <ClInclude Include="..\..\..\Source\Lib\Uncompressed\AIFF\AIFF.h" />
+    <ClInclude Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.h" />
     <ClInclude Include="..\..\..\Source\Lib\Utils\BitStream\BitStream.h" />
     <ClInclude Include="..\..\..\Source\Lib\Config.h" />
     <ClInclude Include="..\..\..\Source\Lib\Utils\Buffer\Buffer.h" />
@@ -98,6 +99,7 @@
     <ClCompile Include="..\..\..\Source\Lib\Compressed\RAWcooked\Reversibility.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Compressed\RAWcooked\Track.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Uncompressed\AIFF\AIFF.cpp" />
+    <ClCompile Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Utils\CRC32\ZenCRC32.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Uncompressed\DPX\DPX.cpp" />
     <ClCompile Include="..\..\..\Source\Lib\Utils\Errors\Errors.cpp" />

--- a/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj.filters
+++ b/Project/MSVC2019/Lib/RAWcooked_Lib.vcxproj.filters
@@ -148,6 +148,12 @@
     <Filter Include="Header Files\Utils\Buffer">
       <UniqueIdentifier>{56157e64-cae9-4303-8afc-226380ab1406}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Uncompressed\EXR">
+      <UniqueIdentifier>{1c19204a-4553-4ffa-a28d-3845c589e947}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Uncompressed\EXR">
+      <UniqueIdentifier>{a2799b00-8701-4fd0-9657-36a4e798c82c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Source\Lib\Utils\BitStream\BitStream.h">
@@ -369,6 +375,9 @@
     <ClInclude Include="..\..\..\Source\Lib\CoDec\Wrapper.h">
       <Filter>Header Files\CoDec</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.h">
+      <Filter>Header Files\Uncompressed\EXR</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Source\Lib\Utils\CRC32\ZenCRC32.cpp">
@@ -523,6 +532,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Source\Lib\CoDec\Wrapper.cpp">
       <Filter>Source Files\CoDec</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Lib\Uncompressed\EXR\EXR.cpp">
+      <Filter>Source Files\Uncompressed\EXR</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -119,6 +119,11 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
                 Command += " -f image2 -c:v dpx";
             if (!Streams[i].Flavor.compare(0, 5, "TIFF/"))
                 Command += " -f image2 -c:v tiff";
+            if (!Streams[i].Flavor.compare(0, 4, "EXR/"))
+            {
+                Command += " -f image2 -c:v exr -consider_float16_as_uint16 1";
+                Global.OutputOptions["metadata:s:v"] = "WARNING=\"Pixel content is IEEE 754 floating-point format\"";
+            }
 
             // FileName_StartNumber (if needed)
             if (!Streams[i].FileName_StartNumber.empty())
@@ -226,6 +231,8 @@ int output::FFmpeg_Command(const char* FileName, global& Global)
                 Command += " -c:v dpx";
             if (!Streams[i].Flavor.compare(0, 5, "TIFF/"))
                 Command += " -c:v tiff";
+            if (!Streams[i].Flavor.compare(0, 4, "EXR/"))
+                Command += " -c:v exr -consider_float16_as_uint16 1";
 
             // Write the list of files
             auto FileList_File = new intermediate_write;

--- a/Source/Lib/CoDec/FFV1/FFV1_Slice.cpp
+++ b/Source/Lib/CoDec/FFV1/FFV1_Slice.cpp
@@ -407,7 +407,7 @@ void slice::SliceContent_LineThenPlane()
         sample[x][1] = NULL;
     }
 
-    transform_jpeg2000rct Transform(RawFrame, P->bits_per_raw_sample, y, x);
+    transform_jpeg2000rct Transform(RawFrame, P->bits_per_raw_sample, y, x, w, h);
 
     for (size_t y = 0; y < h; y++)
     {

--- a/Source/Lib/CoDec/FFV1/Transform/FFV1_Transform_JPEG2000RCT.h
+++ b/Source/Lib/CoDec/FFV1/Transform/FFV1_Transform_JPEG2000RCT.h
@@ -19,7 +19,7 @@ class raw_frame;
 class transform_jpeg2000rct
 {
 public:
-    transform_jpeg2000rct(raw_frame* RawFrame, size_t Bits, size_t y_offset, size_t x_offset);
+    transform_jpeg2000rct(raw_frame* RawFrame, size_t Bits, size_t y_offset, size_t x_offset, size_t w = 0, size_t h = 0);
 
     void From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);
 
@@ -34,6 +34,7 @@ private:
     void FFmpeg_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);
     void DPX_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);
     void TIFF_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);
+    void EXR_From(size_t w, pixel_t* Y, pixel_t* U, pixel_t* V, pixel_t* A);
 };
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/CoDec/Wrapper.cpp
+++ b/Source/Lib/CoDec/Wrapper.cpp
@@ -8,6 +8,7 @@
 #include "Lib/CoDec/Wrapper.h"
 #include "Lib/Uncompressed/DPX/DPX.h"
 #include "Lib/Uncompressed/TIFF/TIFF.h"
+#include "Lib/Uncompressed/EXR/EXR.h"
 #include "Lib/Uncompressed/WAV/WAV.h"
 #include "Lib/Uncompressed/AIFF/AIFF.h"
 #include "Lib/Uncompressed/HashSum/HashSum.h"

--- a/Source/Lib/Compressed/RAWcooked/Track.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Track.cpp
@@ -12,6 +12,7 @@
 #include "Lib/Compressed/RAWcooked/Reversibility.h"
 #include "Lib/Uncompressed/DPX/DPX.h"
 #include "Lib/Uncompressed/TIFF/TIFF.h"
+#include "Lib/Uncompressed/EXR/EXR.h"
 #include "Lib/Uncompressed/WAV/WAV.h"
 #include "Lib/Uncompressed/AIFF/AIFF.h"
 //---------------------------------------------------------------------------
@@ -158,6 +159,7 @@ input_base_uncompressed* track_info::InitOutput_Find()
     case format_kind::video:
         TEST_OUTPUT(dpx, DPX);
         TEST_OUTPUT(tiff, TIFF);
+        TEST_OUTPUT(exr, EXR);
         break;
     case format_kind::audio:
         TEST_OUTPUT(wav, None);

--- a/Source/Lib/License/License_Internal.h
+++ b/Source/Lib/License/License_Internal.h
@@ -12,6 +12,7 @@
 //---------------------------------------------------------------------------
 #include "Lib/Uncompressed/DPX/DPX.h"
 #include "Lib/Uncompressed/TIFF/TIFF.h"
+#include "Lib/Uncompressed/EXR/EXR.h"
 #include "Lib/Uncompressed/WAV/WAV.h"
 #include "Lib/Uncompressed/AIFF/AIFF.h"
 #include "Lib/License/License.h"
@@ -93,6 +94,7 @@ static const license_info License_Infos[] =
     { "encoders/decoders"   , encoder_Max           , Encoders_String       },
     { "DPX flavors"         , dpx::flavor_Max       , DPX_Flavor_String     },
     { "TIFF flavors"        , tiff::flavor_Max      , TIFF_Flavor_String    },
+    { "EXR flavors"         , exr::flavor_Max       , EXR_Flavor_String     },
     { "WAV flavors"         , wav::flavor_Max       , WAV_Flavor_String     },
     { "AIFF flavors"        , aiff::flavor_Max      , AIFF_Flavor_String    },
 };
@@ -118,6 +120,7 @@ public:
     void                SetSupported(parser Parser, uint8_t Flavor) { SetSupported(License_Parser_Offset + Parser, Flavor); }
     void                SetSupported(dpx::flavor Flavor) { SetSupported(Parser_DPX, (uint8_t)Flavor); }
     void                SetSupported(tiff::flavor Flavor) { SetSupported(Parser_TIFF, (uint8_t)Flavor); }
+    void                SetSupported(exr::flavor Flavor) { SetSupported(Parser_EXR, (uint8_t)Flavor); }
     void                SetSupported(wav::flavor Flavor) { SetSupported(Parser_WAV, (uint8_t)Flavor); }
     void                SetSupported(aiff::flavor Flavor) { SetSupported(Parser_AIFF, (uint8_t)Flavor); }
     bool                IsSupported(uint8_t Type, uint8_t SubType);

--- a/Source/Lib/Uncompressed/EXR/EXR.cpp
+++ b/Source/Lib/Uncompressed/EXR/EXR.cpp
@@ -1,0 +1,703 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+#include "Lib/Uncompressed/EXR/EXR.h"
+#include "Lib/Compressed/RAWcooked/RAWcooked.h"
+#include <sstream>
+#include <ios>
+using namespace std;
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Errors
+
+namespace exr_issue {
+
+namespace undecodable
+{
+
+static const char* MessageText[] =
+{
+    "file smaller than expected",
+    "Version number",
+    "Version flags",
+    "Expected data size is bigger than real file size",
+};
+
+enum code : uint8_t
+{
+    BufferOverflow,
+    VersionNumber,
+    VersionFlags,
+    DataSize,
+    Max
+};
+
+} // unparsable
+
+namespace unsupported
+{
+
+static const char* MessageText[] =
+{
+    // Unsupported
+    "chList features (pLinear / reserved / xSampling / ySampling)",
+    "compression",
+    "dataWindow",
+    "displayWindow",
+    "framesPerSecond",
+    "imageRotation",
+    "lineOrder",
+    "screenWindowCenter",
+    "screenWindowWidth",
+    //"Encoding",
+    "Header field name",
+    "Flavor (colorSpace / pixelType combination)",
+    "Internal error",
+};
+
+enum code : uint8_t
+{
+    chListFeatures,
+    compression,
+    dataWindow,
+    displayWindow,
+    framesPerSecond,
+    imageRotation,
+    lineOrder,
+    screenWindowCenter,
+    screenWindowWidth,
+    //Encoding,
+    FieldName,
+    Flavor,
+    InternalError,
+    Max
+};
+
+namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const char*), IncoherencyMessage); }
+
+} // unsupported
+
+namespace invalid
+{
+
+static const char* MessageText[] =
+{
+    "Size of field name",
+    "Size of chList",
+    "Size of chList channel name",
+};
+
+enum code : uint8_t
+{
+    FieldNameSize,
+    chListSize,
+    chListChannelNameSize,
+    Max
+};
+
+namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const char*), IncoherencyMessage); }
+
+} // invalid
+
+const char** ErrorTexts[] =
+{
+    undecodable::MessageText,
+    unsupported::MessageText,
+    nullptr,
+    invalid::MessageText,
+};
+
+static_assert(error::type_Max == sizeof(ErrorTexts) / sizeof(const char**), IncoherencyMessage);
+
+} // exr_issue
+
+using namespace exr_issue;
+
+//---------------------------------------------------------------------------
+// Enums
+enum class colorspace : uint8_t
+{
+    RGB,
+};
+
+enum class pixeltype : uint8_t
+{
+    Uint,
+    Half,
+    Float,
+};
+
+static const char* TypeText[] =
+{
+    "box2i",
+    "chlist",
+    "chromaticities",
+    "compression",
+    "float",
+    "lineOrder",
+    "int",
+    "string",
+    "rational",
+    "timecode",
+    "v2f",
+};
+
+enum class type : uint8_t
+{
+    box2i,
+    chlist,
+    chromaticities,
+    compression,
+    Float,
+    lineOrder,
+    Int,
+    String,
+    rational,
+    timecode,
+    v2f,
+    Max
+};
+static_assert((size_t)type::Max == sizeof(TypeText) / sizeof(const char*), IncoherencyMessage);
+
+//---------------------------------------------------------------------------
+// Tested cases
+struct exr_tested
+{
+    colorspace                  ColorSpace;
+    pixeltype                   pixelType;
+
+    bool operator == (const exr_tested &Value) const
+    {
+        return ColorSpace == Value.ColorSpace
+            && pixelType == Value.pixelType;
+    }
+};
+struct exr_also
+{
+    exr_tested                  Test;
+    exr::flavor                 Flavor;
+};
+
+struct exr_tested EXR_Tested[] =
+{
+    { colorspace::RGB      , pixeltype::Half },
+};
+static_assert(exr::flavor_Max == sizeof(EXR_Tested) / sizeof(exr_tested), IncoherencyMessage);
+
+//***************************************************************************
+// EXR
+//***************************************************************************
+
+//---------------------------------------------------------------------------
+exr::exr(errors* Errors_Source) :
+    input_base_uncompressed_video(Errors_Source, Parser_EXR, true)
+{
+}
+
+//---------------------------------------------------------------------------
+exr::~exr()
+{
+}
+
+//---------------------------------------------------------------------------
+void exr::ParseBuffer()
+{
+    // Test that it is a EXR
+    if (Buffer.Size() < 8)
+        return;
+
+    Buffer_Offset = 0;
+    uint32_t MagicNumber = Get_B4();
+    if (MagicNumber != 0x762F3101)
+        return;
+    SetDetected();
+
+    uint32_t Version = Get_B4();
+    switch (Version >> 24)
+    {
+    case 0x02:
+        break;
+    default:
+        Undecodable(undecodable::VersionNumber);
+        return;
+    }
+    bool LongName = false;
+    if (Version&0xFFFFFF)
+    {
+        Undecodable(undecodable::VersionFlags);
+        return;
+    }
+
+    IsBigEndian = false;
+    exr_tested Info;
+    Info.ColorSpace = (colorspace)-1;
+    Info.pixelType = (pixeltype)-1;
+    uint32_t Width = 0;
+    uint32_t Height = 0;
+    uint32_t displayWidth = 0;
+    uint32_t displayHeight = 0;
+    bool displayIsPresent = false;
+    bool UnsupportedFieldName = false;
+    while (Buffer_Offset < Buffer.Size())
+    {
+        //Name
+        size_t name_End = 0;
+        while (name_End < Buffer.Size() - Buffer_Offset)
+        {
+            if (!Buffer[Buffer_Offset + name_End])
+                break;
+            if (name_End > (LongName ? 255 : 31))
+                break;
+            name_End++;
+        }
+        if (name_End >= Buffer.Size() - Buffer_Offset)
+        {
+            Invalid(invalid::FieldNameSize);
+            return;
+        }
+        if (name_End > (LongName ? 255 : 31))
+        {
+            Invalid(invalid::FieldNameSize);
+            return;
+        }
+        if (!name_End)
+        {
+            Buffer_Offset++;
+            break; // Now it is image data
+        }
+
+        //Type
+        size_t type_End = 0;
+        while (name_End + 1 + type_End < Buffer.Size() - Buffer_Offset)
+        {
+            if (!Buffer[Buffer_Offset + name_End + 1 + type_End])
+                break;
+            if (type_End > (LongName ? 255 : 31))
+                break;
+            type_End++;
+        }
+        if (name_End + 1 + type_End > Buffer.Size() - Buffer_Offset)
+        {
+            Invalid(invalid::FieldNameSize);
+            return;
+        }
+        if (type_End > (LongName ? 255 : 31) || name_End + 1 + type_End + 1 + 4 >= Buffer.Size() - Buffer_Offset)
+        {
+            Invalid(invalid::FieldNameSize);
+            return;
+        }
+
+        // Size
+        Buffer_Offset += name_End + 1 + type_End + 1;
+        uint32_t Size = Get_L4();
+        if (Size > Buffer.Size() - Buffer_Offset)
+        {
+            Invalid(invalid::FieldNameSize);
+            return;
+        }
+
+        // Parse
+        auto name = (const char*)Buffer.Data() + Buffer_Offset - (name_End + 1 + type_End + 1 + 4);
+        auto type = (const char*)Buffer.Data() + Buffer_Offset - (               type_End + 1 + 4);
+        #define CASE_F(_NAME,_TYPE) else if (!strcmp(_NAME, name) && !strcmp(TypeText[(int)_TYPE], type))  // Full parsing needed
+        #define CASE_S(_NAME,_TYPE) else if (!strcmp(_NAME, name) && !strcmp(TypeText[(int)_TYPE], type)){Buffer_Offset += Size;} // Supported and skipped
+        #define CASE_S_STARTWITH(_NAME) else if (!strncmp(_NAME, name, strlen(_NAME))){Buffer_Offset += Size;} // Supported and skipped
+        if (false);
+        CASE_S("acesImageContainerFlag", type::Int)
+        CASE_S("adoptedNeutral", type::v2f)
+        CASE_S_STARTWITH("arri.")
+        CASE_S_STARTWITH("camera")
+        CASE_S("capDate", type::String)
+        CASE_F("captureRate", type::rational)
+        {
+            if (Size != 8)
+            {
+                Unsupported(unsupported::framesPerSecond);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                auto FrameRate_N = Get_L4();
+                auto FrameRate_D = Get_L4();
+                if (FrameRate_N && FrameRate_D && InputInfo && !InputInfo->FrameRate)
+                    InputInfo->FrameRate = ((decltype(InputInfo->FrameRate))FrameRate_N) / FrameRate_D;
+            }
+        }
+        CASE_F("channels", type::chlist)
+        {
+            if (!Size)
+            {
+                Invalid(invalid::chListSize); // Should finish with a single null byte
+                return;
+            }
+            uint32_t ColorSpace = 0;
+            uint8_t Count = 0;
+            size_t End = Buffer_Offset + Size - 1;
+            while (17 <= End - Buffer_Offset) // channelName ending null + pixelType + Others
+            {
+                // channelName
+                size_t channelName_End = 0;
+                while (channelName_End < Buffer.Size() - Buffer_Offset && channelName_End <= 255)
+                {
+                    if (!Buffer[Buffer_Offset + channelName_End] || channelName_End > 255)
+                        break;
+                    channelName_End++;
+                }
+                if (channelName_End > End - Buffer_Offset - 17)
+                {
+                    Invalid(invalid::chListSize);
+                    return;
+                }
+                if (!channelName_End || channelName_End > 255)
+                {
+                    Invalid(invalid::chListChannelNameSize);
+                    return;
+                }
+                if (Count > 3 || channelName_End != 1)
+                    ColorSpace = (uint32_t)-1;
+                else
+                    ColorSpace |= Buffer[Buffer_Offset] << (Count * 8);
+                Buffer_Offset += channelName_End + 1;
+
+                // pixelType
+                auto pixelTypeValue = Get_L4();
+                auto pixelType = (pixelTypeValue >= (1 << sizeof(Info.pixelType))) ? (pixeltype)-1 : (pixeltype)pixelTypeValue;
+                if (!Count)
+                    Info.pixelType = pixelType; // Storing the first value
+                else if (pixelType != Info.pixelType)// Testing that all but first values are same
+                    Info.pixelType = (pixeltype)-1;
+
+                // Others
+                if (Get_L4() || Get_L4() != 1 || Get_L4() != 1)
+                {
+                    Unsupported(unsupported::chListFeatures); // pLinear / reserved / xSampling / ySampling
+                    return;
+                }
+
+                Count++;
+            }
+            if (End - Buffer_Offset || Get_L1())
+            {
+                Invalid(invalid::chListSize); // Should finish with a single null byte
+                return;
+            }
+
+            switch (ColorSpace)
+            {
+                case 0x00524742: Info.ColorSpace = colorspace::RGB; break;
+                default:;
+            }
+
+        }
+        CASE_S("chromaticities", type::chromaticities)
+        CASE_S_STARTWITH("com.arri.")
+        CASE_S("comments", type::String)
+        CASE_F("compression", type::compression)
+        {
+            if (Size != 1)
+            {
+                Unsupported(unsupported::compression);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L1())
+                    Unsupported(unsupported::compression);
+            }
+        }
+        CASE_F("dataWindow", type::box2i)
+        {
+            if (Size != 16)
+            {
+                Unsupported(unsupported::dataWindow);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L4() || Get_L4())
+                    Unsupported(unsupported::dataWindow);
+                Width = Get_L4();
+                Height = Get_L4();
+                if (!Width || !Height)
+                    Unsupported(unsupported::dataWindow);
+            }
+        }
+        CASE_F("displayWindow", type::box2i)
+        {
+            if (Size != 16)
+            {
+                Unsupported(unsupported::displayWindow);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L4() || Get_L4())
+                    Unsupported(unsupported::displayWindow);
+                displayWidth = Get_L4();
+                displayHeight = Get_L4();
+                if (!displayWidth || !displayHeight)
+                    Unsupported(unsupported::displayWindow);
+                else
+                    displayIsPresent = true;
+            }
+        }
+        CASE_S("expTime", type::Float)
+        CASE_S("focalLength", type::Float)
+        CASE_S("focus", type::Float)
+        CASE_F("framesPerSecond", type::rational)
+        {
+            if (Size != 8)
+            {
+                Unsupported(unsupported::framesPerSecond);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                auto FrameRate_N = Get_L4();
+                auto FrameRate_D = Get_L4();
+                if (!FrameRate_N || !FrameRate_D)
+                    Unsupported(unsupported::framesPerSecond);
+                else if (InputInfo)
+                    InputInfo->FrameRate = ((decltype(InputInfo->FrameRate))FrameRate_N) / FrameRate_D;
+            }
+        }
+        CASE_S("imageCounter", type::Int)
+        CASE_F("imageRotation", type::Float)
+        {
+            if (Size != 4)
+            {
+                Unsupported(unsupported::imageRotation);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L4())
+                    Unsupported(unsupported::imageRotation);
+            }
+        }
+        CASE_S_STARTWITH("interim.")
+        CASE_S("isoSpeed", type::Float)
+        CASE_S("lensMake", type::String)
+        CASE_S("lensSerialNumber", type::String)
+        CASE_F("lineOrder", type::lineOrder)
+        {
+            if (Size != 1)
+            {
+                Unsupported(unsupported::lineOrder);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L1())
+                    Unsupported(unsupported::lineOrder);
+            }
+        }
+        CASE_S("originalImageFlag", type::Int)
+        CASE_S("owner", type::String)
+        CASE_S("pixelAspectRatio", type::Float)
+        CASE_S("reelName", type::String)
+        CASE_S("recorderFirmwareVersion", type::String)
+        CASE_S("recorderMake", type::String)
+        CASE_S("recorderModel", type::String)
+        CASE_S("reelName", type::String)
+        CASE_F("screenWindowCenter", type::v2f)
+        {
+            if (Size != 8)
+            {
+                Unsupported(unsupported::screenWindowCenter);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_L8())
+                    Unsupported(unsupported::screenWindowCenter);
+            }
+        }
+        CASE_F("screenWindowWidth", type::Float)
+        {
+            if (Size != 4)
+            {
+                Unsupported(unsupported::screenWindowWidth);
+                Buffer_Offset += Size;
+            }
+            else
+            {
+                if (Get_XF4() != 1)
+                    Unsupported(unsupported::screenWindowWidth);
+            }
+        }
+        CASE_S("storageMediaSerialNumber", type::String)
+        CASE_S("timeCode", type::timecode)
+        CASE_S("timecodeRate", type::Int)
+        else
+        {
+            UnsupportedFieldName = true;
+            Buffer_Offset += Size;
+        }
+    }
+
+    // Supported?
+    if (displayIsPresent && (Width != displayWidth || Height != displayHeight))
+        Unsupported(unsupported::displayWindow);
+    Width++;
+    Height++;
+    if (UnsupportedFieldName)
+        Unsupported(unsupported::FieldName);
+    for (const auto& EXR_Tested_Item : EXR_Tested)
+    {
+        if (EXR_Tested_Item == Info)
+        {
+            Flavor = (decltype(Flavor))(&EXR_Tested_Item - EXR_Tested);
+            break;
+        }
+    }
+    if (Flavor == (decltype(Flavor))-1)
+        Unsupported(unsupported::Flavor);
+    if (HasErrors())
+        return;
+
+    // Slices count
+    // Computing optimal count of slices. TODO: agree with everyone about the goal and/or permit multiple formulas
+    // Current idea:
+    // - have some SIMD compatible slice count (e.g. AVX-512 has 16 32-bit blocks, let's take multiples of 16)
+    // - each slice has around 256 KiB of data, there is a similar risk of losing 1 LTO block (correction code per block, to be confirmed but looks like a 256 KiB block size is classic and LTFS 2.4 spec indicates 512 KiB in the example)
+    // This leads to:
+    // SD: 16 slices (10-bit) or 24 slices (16-bit)
+    // HD/2K: 64 slices (10-bit) or 96 slices (16-bit)
+    // UHD/4K: 256 slices (10-bit) or 384 slices (16-bit)
+    // 
+    slice_x = 4;
+    if (Width >= 1440) // more than 2/3 of 1920, so e.g. DV100 is included
+        slice_x <<= 1;
+    if (Width >= 2880) // more than 3/2 of 1920, oversampled HD is not included
+        slice_x <<= 1;
+    if (true) //Info.BitDepth > 10)
+        slice_x = slice_x * 3 / 2; // 1.5x more slices if 16-bit
+    if (slice_x > Width / 2)
+        slice_x = Width / 2;
+    if (slice_x > Height / 2)
+        slice_x = Height / 2;
+    if (!slice_x)
+        slice_x = 1;
+
+    // Computing which slice count is suitable
+    slice_y = slice_x;
+
+    // Offset Tables
+    Buffer_Offset += 8 * Height;
+    
+    // Computing OffsetAfterData
+    size_t ContentSize_Multiplier = BytesPerBlock((flavor)Flavor);
+    size_t OffsetAfterData = Buffer_Offset + (ContentSize_Multiplier * Width + 8) * Height;
+    if (OffsetAfterData > Buffer.Size())
+    {
+        if (!Actions[Action_AcceptTruncated])
+            Undecodable(undecodable::DataSize);
+    }
+
+    // Can we compress?
+    if (!HasErrors())
+        SetSupported();
+
+    // Write RAWcooked file
+    if (IsSupported() && RAWcooked)
+    {
+        RAWcooked->Unique = false;
+        RAWcooked->BeforeData = Buffer.Data();
+        RAWcooked->BeforeData_Size = Buffer_Offset;
+        RAWcooked->AfterData = Buffer.Data() + OffsetAfterData;
+        RAWcooked->AfterData_Size = Buffer.Size() - OffsetAfterData;
+        RAWcooked->InData = nullptr;
+        RAWcooked->InData_Size = 0;
+        RAWcooked->FileSize = (uint64_t)-1;
+        if (Actions[Action_Hash])
+        {
+            Hash();
+            RAWcooked->HashValue = &HashValue;
+        }
+        else
+            RAWcooked->HashValue = nullptr;
+        RAWcooked->IsAttachment = false;
+        RAWcooked->Parse();
+    }
+}
+
+//---------------------------------------------------------------------------
+void exr::BufferOverflow()
+{
+    Undecodable(undecodable::BufferOverflow);
+}
+
+//---------------------------------------------------------------------------
+string exr::Flavor_String()
+{
+    return EXR_Flavor_String(Flavor);
+}
+
+//---------------------------------------------------------------------------
+size_t exr::BytesPerBlock(exr::flavor /*Flavor*/)
+{
+    return 6;
+}
+
+//---------------------------------------------------------------------------
+size_t exr::PixelsPerBlock(exr::flavor /*Flavor*/)
+{
+    return 1;
+}
+
+//---------------------------------------------------------------------------
+static colorspace ColorSpace(exr::flavor Flavor)
+{
+    return EXR_Tested[(size_t)Flavor].ColorSpace;
+}
+static const char* ColorSpace_String(exr::flavor Flavor)
+{
+    switch (ColorSpace(Flavor))
+    {
+    case colorspace::RGB : return "RGB";
+    }
+    return "";
+}
+
+//---------------------------------------------------------------------------
+static uint8_t BitDepth(exr::flavor /*Flavor*/)
+{
+    return 16;
+}
+static const char* BitDepth_String(exr::flavor /*Flavor*/)
+{
+    return "16";
+}
+
+//---------------------------------------------------------------------------
+static const char* PixelType_String(exr::flavor Flavor)
+{
+    switch (EXR_Tested[(size_t)Flavor].pixelType)
+    {
+    case pixeltype::Float : return "Float";
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------
+string EXR_Flavor_String(uint8_t Flavor)
+{
+    string ToReturn("EXR/Raw/");
+    ToReturn += ColorSpace_String((exr::flavor)Flavor);
+    ToReturn += '/';
+    ToReturn += BitDepth_String((exr::flavor)Flavor);
+    ToReturn += "bit";
+    const char* Value = PixelType_String((exr::flavor)Flavor);
+    if (Value && Value[0])
+    {
+        ToReturn += '/';
+        ToReturn += Value;
+    }
+    return ToReturn;
+}

--- a/Source/Lib/Uncompressed/EXR/EXR.h
+++ b/Source/Lib/Uncompressed/EXR/EXR.h
@@ -1,0 +1,56 @@
+/*  Copyright (c) MediaArea.net SARL & AV Preservation by reto.ch.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+//---------------------------------------------------------------------------
+#ifndef EXRH
+#define EXRH
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+#include "Lib/Utils/FileIO/Input_Base.h"
+#include <cstdint>
+#include <cstddef>
+//---------------------------------------------------------------------------
+
+namespace exr_issue
+{
+    namespace undecodable { enum code : uint8_t; }
+    namespace unsupported { enum code : uint8_t; }
+    namespace invalid     { enum code : uint8_t; }
+}
+
+class exr : public input_base_uncompressed_video
+{
+public:
+    exr(errors* Errors = nullptr);
+    ~exr();
+
+    // General info
+    string                      Flavor_String();
+    size_t                      slice_x;
+    size_t                      slice_y;
+
+    // Flavors
+    ENUM_BEGIN(flavor)
+        Raw_RGB_16,
+    ENUM_END(flavor)
+
+    // Info about flavors
+    static size_t               BytesPerBlock(flavor Flavor);
+    static size_t               PixelsPerBlock(flavor Flavor); // Need no overlap every x pixels
+
+private:
+    void                        ParseBuffer();
+    void                        BufferOverflow();
+    void                        Undecodable(exr_issue::undecodable::code Code) { input_base::Undecodable((error::undecodable::code)Code); }
+    void                        Unsupported(exr_issue::unsupported::code Code) { input_base::Unsupported((error::unsupported::code)Code); }
+    void                        Invalid(exr_issue::invalid::code Code) { input_base::Invalid((error::invalid::code)Code); }
+};
+
+string EXR_Flavor_String(uint8_t Flavor);
+
+//---------------------------------------------------------------------------
+#endif

--- a/Source/Lib/Utils/Errors/Errors.cpp
+++ b/Source/Lib/Utils/Errors/Errors.cpp
@@ -13,6 +13,7 @@
 //---------------------------------------------------------------------------
 namespace dpx_issue { extern const char** ErrorTexts[]; }
 namespace tiff_issue { extern const char** ErrorTexts[]; }
+namespace exr_issue { extern const char** ErrorTexts[]; }
 namespace wav_issue { extern const char** ErrorTexts[]; }
 namespace aiff_issue { extern const char** ErrorTexts[]; }
 namespace matroska_issue { extern const char** ErrorTexts[]; }
@@ -26,6 +27,7 @@ static const char*** AllErrorTexts[] =
 {
     dpx_issue::ErrorTexts,
     tiff_issue::ErrorTexts,
+    exr_issue::ErrorTexts,
     wav_issue::ErrorTexts,
     aiff_issue::ErrorTexts,
     matroska_issue::ErrorTexts,
@@ -47,6 +49,7 @@ static const char* ParserNames[] =
 {
     "DPX",
     "TIFF",
+    "EXR",
     "WAV",
     "AIFF",
     "Matroska",

--- a/Source/Lib/Utils/Errors/Errors.h
+++ b/Source/Lib/Utils/Errors/Errors.h
@@ -27,6 +27,7 @@ enum parser
 {
     Parser_DPX,
     Parser_TIFF,
+    Parser_EXR,
     Parser_WAV,
     Parser_AIFF,
     Uncompressed_Max, // After this line, this isn't parsers of uncompressed data

--- a/Source/Lib/Utils/FileIO/Input_Base.cpp
+++ b/Source/Lib/Utils/FileIO/Input_Base.cpp
@@ -140,6 +140,16 @@ uint32_t input_base::Get_B4()
 }
 
 //---------------------------------------------------------------------------
+uint64_t input_base::Get_L8()
+{
+    TEST_BUFFEROVERFLOW(8);
+
+    uint64_t ToReturn = Buffer[Buffer_Offset + 0] | (Buffer[Buffer_Offset + 1] << 8) | (Buffer[Buffer_Offset + 2] << 16) | (Buffer[Buffer_Offset + 3] << 24) | ((uint64_t)Buffer[Buffer_Offset + 4] << 32) | ((uint64_t)Buffer[Buffer_Offset + 5] << 40) | ((uint64_t)Buffer[Buffer_Offset + 6] << 48) | ((uint64_t)Buffer[Buffer_Offset + 7] << 56);
+    Buffer_Offset += 8;
+    return ToReturn;
+}
+
+//---------------------------------------------------------------------------
 uint64_t input_base::Get_B8()
 {
     TEST_BUFFEROVERFLOW(8);

--- a/Source/Lib/Utils/FileIO/Input_Base.h
+++ b/Source/Lib/Utils/FileIO/Input_Base.h
@@ -105,6 +105,7 @@ protected:
     uint32_t                    Get_B4();
     uint32_t                    Get_X4() { return IsBigEndian ? Get_B4() : Get_L4(); }
     double                      Get_XF4();
+    uint64_t                    Get_L8();
     uint64_t                    Get_B8();
     long double                 Get_BF10();
     uint64_t                    Get_EB();

--- a/Source/Lib/Utils/RawFrame/RawFrame.cpp
+++ b/Source/Lib/Utils/RawFrame/RawFrame.cpp
@@ -8,6 +8,7 @@
 #include "Lib/Utils/RawFrame/RawFrame.h"
 #include "Lib/Uncompressed/DPX/DPX.h"
 #include "Lib/Uncompressed/TIFF/TIFF.h"
+#include "Lib/Uncompressed/EXR/EXR.h"
 #include <algorithm>
 //---------------------------------------------------------------------------
 
@@ -26,6 +27,7 @@ void raw_frame::Create(size_t colorspace_type, size_t width, size_t height, size
         case flavor::FFmpeg: FFmpeg_Create(colorspace_type, width, height, bits_per_raw_sample, chroma_planes, alpha_plane, h_chroma_subsample, v_chroma_subsample); break;
         case flavor::DPX: DPX_Create(colorspace_type, width, height); break;
         case flavor::TIFF: TIFF_Create(colorspace_type, width, height); break;
+        case flavor::EXR: EXR_Create(colorspace_type, width, height); break;
         case flavor::None:;
     }
 }
@@ -76,6 +78,17 @@ void raw_frame::TIFF_Create(size_t colorspace_type, size_t width, size_t height)
     {
         case 1: // JPEG2000-RCT --> RGB
                 Planes_.push_back(new plane(width, height, tiff::BytesPerBlock((tiff::flavor)Flavor_Private), tiff::PixelsPerBlock((tiff::flavor)Flavor_Private)));
+        default: ;
+    }
+}
+
+//---------------------------------------------------------------------------
+void raw_frame::EXR_Create(size_t colorspace_type, size_t width, size_t height)
+{
+    switch (colorspace_type)
+    {
+        case 1: // JPEG2000-RCT --> RGB
+                Planes_.push_back(new plane(width, height, exr::BytesPerBlock((exr::flavor)Flavor_Private), exr::PixelsPerBlock((exr::flavor)Flavor_Private), 8));
         default: ;
     }
 }

--- a/Source/Lib/Utils/RawFrame/RawFrame.h
+++ b/Source/Lib/Utils/RawFrame/RawFrame.h
@@ -32,18 +32,19 @@ public:
 
     struct plane
     {
-        plane(size_t NewWidth, size_t NewHeight, size_t NewBytesPerBlock, size_t NewPixelsPerBlock = 1)
+        plane(size_t NewWidth, size_t NewHeight, size_t NewBytesPerBlock, size_t NewPixelsPerBlock = 1, size_t Width_Prefix = 0)
             :
             Width_(NewWidth),
             Height_(NewHeight),
             BytesPerBlock_(NewBytesPerBlock),
-            PixelsPerBlock_(NewPixelsPerBlock)
+            PixelsPerBlock_(NewPixelsPerBlock),
+            Width_Prefix_(Width_Prefix)
         {
             Width_Padding_ = 0; //TODO: option for padding size
             if (Width_Padding_)
                 Width_Padding_ -= Width_ % Width_Padding_;
 
-            Buffer_.Create((Width_ + Width_Padding_) * Height_ * BytesPerBlock_ / PixelsPerBlock_);
+            Buffer_.Create(AllBytesPerLine() * Height_);
         }
 
         const buffer& Buffer() const
@@ -58,7 +59,7 @@ public:
 
         size_t AllBytesPerLine() const
         {
-            return (Width_ + Width_Padding_) * BytesPerBlock_ / PixelsPerBlock_;
+            return Width_Prefix_ + (Width_ * BytesPerBlock_ / PixelsPerBlock_) + Width_Padding_;
         }
 
         size_t BytesPerBlock() const
@@ -74,6 +75,7 @@ public:
     //private:
         buffer                  Buffer_;
         size_t                  Width_;
+        size_t                  Width_Prefix_;
         size_t                  Width_Padding_;
         size_t                  Height_;
         size_t                  BytesPerBlock_;
@@ -135,6 +137,7 @@ public:
         FFmpeg,
         DPX,
         TIFF,
+        EXR,
     ENUM_END(flavor)
     flavor                       Flavor = flavor::None;
 
@@ -164,6 +167,7 @@ public:
     void FFmpeg_Create(size_t colorspace_type, size_t width, size_t height, size_t bits_per_raw_sample, bool chroma_planes, bool alpha_plane, size_t h_chroma_subsample, size_t v_chroma_subsample);
     void DPX_Create(size_t colorspace_type, size_t width, size_t height);
     void TIFF_Create(size_t colorspace_type, size_t width, size_t height);
+    void EXR_Create(size_t colorspace_type, size_t width, size_t height);
     void MergeIn();
 };
 


### PR DESCRIPTION
A [modified version of FFmpeg](https://mediaarea.net/download/snapshots/binary/ffmpeg/), which has an option for handling float values as int values, is required in order to use this feature, as FFV1 does not support 16-bit float.
In comparison to the other formats, the support of EXR will not permit (it is decoded but colors are darker) playback by players not having the modified version of FFmpeg (=all players), but the goal of the sponsor is only the storage optimization.