### PR TITLE
Support of DPX with "v1.0" ("v" in lowercase)

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -133,6 +133,7 @@ Formats/DPX/Flavors/RGB_16_Packed_BE/058142ce-aeb9-4f5c-b3c7-7590f09c757d_000900
 Formats/DPX/Flavors/RGB_16_Packed_BE/RGB_16_bit.dpx pass
 Formats/DPX/Flavors/RGB_16_Packed_LE/Dufay_000001.dpx pass
 Formats/DPX/Conformance/0004_OffsetToImageData/0004_OffsetToImageData_000000.dpx fail
+Formats/DPX/Conformance/0008_VersionNumber/0008_VersionNumber_v.dpx pass
 Formats/TIFF/Features/MultipleContinuousStripOffsets/Lavc.tiff pass
 Formats/TIFF/Flavors/Raw_CMYK_8_U/flower-separated-contig-08.tif fail
 Formats/TIFF/Flavors/Raw_CMYK_8_U/flower-separated-planar-08.tif fail

--- a/Source/Lib/Uncompressed/DPX/DPX.cpp
+++ b/Source/Lib/Uncompressed/DPX/DPX.cpp
@@ -87,6 +87,7 @@ static const char* MessageText[] =
 {
     "Offset to image data in bytes",
     "Total image file size",
+    "Version number of header format",
     "Ditto key",
     "Ditto key is set to \"same as the previous frame\" but header data differs",
     "Number of image elements",
@@ -96,6 +97,7 @@ enum code : uint8_t
 {
     OffsetToImageData,
     TotalImageFileSize,
+    VersionNumber,
     DittoKey,
     DittoKey_NotSame,
     NumberOfElements,
@@ -293,6 +295,7 @@ void dpx::ParseBuffer()
     {
     case 0x56312E3000LL:
     case 0x56322E3000LL:
+    case 0x76312E3000LL:
         break;
     default:
         Undecodable(undecodable::VersionNumber);
@@ -506,6 +509,13 @@ void dpx::ConformanceCheck()
     uint32_t OffsetToImageData = Get_X4();
     if (OffsetToImageData < 1664 || OffsetToImageData > Buffer.Size())
         Invalid(invalid::OffsetToImageData);
+    uint64_t VersionNumber = Get_B8() >> 24;
+    switch (VersionNumber)
+    {
+    case 0x76312E3000LL:
+        Invalid(invalid::VersionNumber);
+    default:;
+    }
     Buffer_Offset = 16;
     uint32_t TotalImageFileSize = Get_X4();
     if (TotalImageFileSize != FileSize)


### PR DESCRIPTION
if ` --conch` is used, there is a warning:

```
Warning: non-conforming DPX Version number of header format.
```

FFmpeg has another one:

```
[dpx @ 00000242E8204480] Unknown header format version v1.0.
```

but accepts it, so let's go.