### PR TITLE
Fix crash with decoding 100K+ files

### DIFF
--- a/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Reversibility.cpp
@@ -361,14 +361,15 @@ void reversibility::filesize::SetData(size_t Pos, uint64_t Value)
         }
         else
         {
+            auto OldMaxCount = MaxCount_;
             if (!MaxCount_)
                 MaxCount_ = 1;
             while (Pos >= MaxCount_)
                 MaxCount_ *= 4;
             auto NewContent = new std::remove_pointer<decltype(Content_)>::type[MaxCount_];
-            if (Content_)
+            if (OldMaxCount)
             {
-                memcpy(NewContent, Content_, MaxCount_ * sizeof(std::remove_pointer<decltype(Content_)>::type));
+                memcpy(NewContent, Content_, OldMaxCount * sizeof(std::remove_pointer<decltype(Content_)>::type));
                 delete[] Content_;
             }
             Content_ = NewContent;


### PR DESCRIPTION
Crash due to access to a wrong place appears to be mostly only Windows, and it does not hurt if the OS does not kill the program, but in any case it is not a good practice to copy content not owned by the program