### PR TITLE
--check option is not with a license lock

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -509,7 +509,6 @@ int global::ManageCommandLine(const char* argv[], int argc)
             else
             {
                 int Value = SetCheck(true);
-                License.Feature(feature::GeneralOptions);
                 if (Value)
                     return Value;
             }


### PR DESCRIPTION
Fix https://github.com/MediaArea/RAWcooked/issues/349.
It was a fully sponsored feature so should not be locked.
(workaround: it was included in --all option)