### PR TITLE
Fix RPM build

### DIFF
--- a/Project/GNU/rawcooked.spec
+++ b/Project/GNU/rawcooked.spec
@@ -35,7 +35,7 @@ RAWcooked provides this service:
 Encodes RAW audio-visual data while permitting reversibility
 
 %prep
-%setup -q -n rawcooked
+%setup -q -n rawcooked-%rawcooked_version
 dos2unix     *.txt
 %__chmod 644 *.html *.txt
 


### PR DESCRIPTION
As the tarred sources contain version information in the top-level directory name, that needs to be taken into account in the prep section of the spec file.

Otherwise the following error appears:
```
# rpmbuild -bb rawcooked.spec 
setting SOURCE_DATE_EPOCH=1514764800
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.MetgeC
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd /root/rpmbuild/BUILD
+ rm -rf rawcooked
+ /usr/bin/gzip -dc /root/rpmbuild/SOURCES/rawcooked_21.09-1.tar.gz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd rawcooked
/var/tmp/rpm-tmp.MetgeC: line 38: cd: rawcooked: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.MetgeC (%prep)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.MetgeC (%prep)

```