### PR TITLE
Smooth reject of Matroska files with newer RAWcooked content

### DIFF
--- a/Source/Lib/CoDec/FFV1/FFV1_Frame.cpp
+++ b/Source/Lib/CoDec/FFV1/FFV1_Frame.cpp
@@ -104,6 +104,9 @@ void ffv1_frame::SetHeight(uint32_t height)
 //---------------------------------------------------------------------------
 bool ffv1_frame::OutOfBand(const uint8_t* Buffer, size_t Buffer_Size)
 {
+    if (!Buffer_Size)
+        return true;
+
     P.ConfigurationRecord_IsPresent = true;
     Clear();
 
@@ -130,11 +133,6 @@ bool ffv1_frame::OutOfBand(const uint8_t* Buffer, size_t Buffer_Size)
 //---------------------------------------------------------------------------
 bool ffv1_frame::Process(const uint8_t* Buffer, size_t Buffer_Size)
 {
-    if (P.num_h_slices >= P.width)
-        return P.Error("FFV1-HEADER-num_h_slices:1");
-    if (P.num_v_slices >= P.height)
-        return P.Error("FFV1-HEADER-num_v_slices:1");
-
     if (!Slices)
     {
         if (P.ConfigurationRecord_IsPresent)
@@ -157,17 +155,16 @@ bool ffv1_frame::Process(const uint8_t* Buffer, size_t Buffer_Size)
     if (!KeyFrame_IsPresent)
         return P.Error("FFV1-FRAME-key_frame-NOINFIRSTFRAME:1");
 
-    if (P.ConfigurationRecord_IsPresent)
-    {
-        //Frame
-        //delete RawFrame;
-        //RawFrame = new raw_frame;
-        RawFrame->Create(P.colorspace_type, P.width, P.height, P.bits_per_raw_sample, P.chroma_planes, P.alpha_plane, ((size_t)1 << P.log2_h_chroma_subsample), ((size_t)1 << P.log2_v_chroma_subsample));
-    }
-
     size_t Slices_Size = 0;
     if (P.ConfigurationRecord_IsPresent)
     {
+        if (P.num_h_slices >= P.width)
+            return P.Error("FFV1-HEADER-num_h_slices:1");
+        if (P.num_v_slices >= P.height)
+            return P.Error("FFV1-HEADER-num_v_slices:1");
+
+        RawFrame->Create(P.colorspace_type, P.width, P.height, P.bits_per_raw_sample, P.chroma_planes, P.alpha_plane, ((size_t)1 << P.log2_h_chroma_subsample), ((size_t)1 << P.log2_v_chroma_subsample));
+
         uint64_t Slices_BufferPos = Buffer_Size;
         while (Slices_BufferPos)
         {

--- a/Source/Lib/Compressed/Matroska/Matroska.cpp
+++ b/Source/Lib/Compressed/Matroska/Matroska.cpp
@@ -788,9 +788,7 @@ void matroska::Segment_Cluster()
     // Init
     for (const auto& TrackInfo_Current : TrackInfo)
         if (TrackInfo_Current && TrackInfo_Current->Init(Buffer.Data()))
-        {
-            //TODO handle errors
-        }
+            Errors->Error(IO_FileChecker, error::type::Undecodable, (error::generic::code)filechecker_issue::undecodable::Format_Undetected, string());
 }
 
 //---------------------------------------------------------------------------
@@ -862,7 +860,8 @@ void matroska::Segment_Tracks_TrackEntry_CodecID()
 void matroska::Segment_Tracks_TrackEntry_CodecPrivate()
 {
     track_info* TrackInfo_Current = TrackInfo[TrackInfo_Pos];
-    TrackInfo_Current->OutOfBand(Buffer.Data() + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset);
+    if (TrackInfo_Current->OutOfBand(Buffer.Data() + Buffer_Offset, Levels[Level].Offset_End - Buffer_Offset))
+        Errors->Error(IO_FileChecker, error::type::Undecodable, (error::generic::code)filechecker_issue::undecodable::Format_Undetected, string());
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Compressed/RAWcooked/Track.cpp
+++ b/Source/Lib/Compressed/RAWcooked/Track.cpp
@@ -89,8 +89,12 @@ bool track_info::Process(const uint8_t* Data, size_t Size)
         if (FrameWriter->OutputFileName.empty() && ReversibilityData->Count())
             Undecodable(reversibility_issue::undecodable::ReversibilityData_FrameCount);
     }
-    if (Wrapper)
-        Wrapper->Process(Data, Size);
+    if (!Wrapper)
+    {
+        Errors->Error(IO_FileChecker, error::type::Undecodable, (error::generic::code)filechecker_issue::undecodable::Format_Undetected, string());
+        return true;
+    }
+    Wrapper->Process(Data, Size);
     if (!ReversibilityData->Unique())
     {
         if (Actions[Action_Conch] || Actions[Action_Coherency])
@@ -114,7 +118,7 @@ bool track_info::OutOfBand(const uint8_t* Data, size_t Size)
         Format = format::None;
 
         // Special case, real format is inside the VFW block
-        if (Size <= 0x28)
+        if (Size < 0x28)
             return true;
 
         uint32_t VFW_Size = ((uint32_t)Data[0]) | (((uint32_t)Data[1]) << 8) | (((uint32_t)Data[2]) << 16) | (((uint32_t)Data[3]) << 24);

--- a/Source/Lib/Utils/FileIO/FileChecker.cpp
+++ b/Source/Lib/Utils/FileIO/FileChecker.cpp
@@ -26,6 +26,7 @@ namespace filechecker_issue {
             "extra frame in compressed file",
             "missing frame in source (extra frames in compressed file)",
             "extra frame in source (missing frames in compressed file)",
+            "track format (unsupported)",
         };
 
         namespace undecodable { static_assert(Max == sizeof(MessageText) / sizeof(const char*), IncoherencyMessage); }

--- a/Source/Lib/Utils/FileIO/FileChecker.h
+++ b/Source/Lib/Utils/FileIO/FileChecker.h
@@ -31,6 +31,7 @@ namespace filechecker_issue
             Frame_Compressed_Extra,
             Frame_Source_Missing,
             Frame_Source_Extra,
+            Format_Undetected,
             Max
         };
 


### PR DESCRIPTION
If RAWcooked content is not supported e.g. a DPX flavor supported only in a later version, there was sometimes a crash instead of a smooth reject of the content.