### PR TITLE
Support of DPX RGB 12-bit Packed BE with non 8-pixel aligned width

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -125,6 +125,15 @@ Formats/DPX/Flavors/RGB_12_FilledA_LE/checkerboard_1080p_nuke_littleendian_12bit
 Formats/DPX/Flavors/RGB_12_Packed_BE/12bit.dpx pass
 Formats/DPX/Flavors/RGB_12_Packed_BE/af093_ifa2006350_10000086400.dpx pass
 Formats/DPX/Flavors/RGB_12_Packed_BE/RGB_12_bit.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_08x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_09x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_10x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_11x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_12x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_13x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_14x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_15x4_orientation0.dpx pass
+Formats/DPX/Flavors/RGB_12_Packed_BE/086449_modified_4300x64_orientation0.dpx pass
 Formats/DPX/Flavors/RGB_16F_Packed_BE/RGB_half_float_16_bit.dpx fail
 Formats/DPX/Flavors/RGB_16_FilledA_BE/checkerboard_1080p_nuke_bigendian_16bit_noalpha.dpx pass
 Formats/DPX/Flavors/RGB_16_FilledA_LE/checkerboard_1080p_nuke_littleendian_16bit_noalpha.dpx pass

--- a/Source/Lib/Transform/Transform.cpp
+++ b/Source/Lib/Transform/Transform.cpp
@@ -131,79 +131,177 @@ public:
 };
 
 //---------------------------------------------------------------------------
+void transform_jpeg2000rct_dpx_Raw_RGB_12_Packed_BE_Finalize(raw_frame* RawFrame, size_t num_h_slices, size_t /*num_v_slices*/)
+{
+    const auto& Plane = RawFrame->Plane(0);
+    auto FrameBufferBefore = Plane->Buffer_Extra().Data();
+
+    const auto Width = Plane->Width();
+    const auto Height = Plane->Height();
+    size_t Slices_w = Width / num_h_slices;
+    for (size_t y = 0; y < Height; y++)
+    {
+        for (size_t slice_x = 0; slice_x < num_h_slices - 1; slice_x++)
+        {
+            auto x = slice_x * Width / num_h_slices;
+            auto x2 = (slice_x + 1) * Width / num_h_slices;
+            if (!(x2 % 8))
+                continue;
+            auto FrameBuffer = Plane->Buffer_Data(x2, y, true);
+            auto FrameBuffer_Temp_32 = (uint32_t*)FrameBuffer;
+            auto FrameBufferBefore_Temp_32 = (uint32_t*)FrameBufferBefore + x / Slices_w;
+            *FrameBuffer_Temp_32 |= *FrameBufferBefore_Temp_32;
+        }
+        FrameBufferBefore += MaxHorizontalSlicesCount * 4;
+    }
+}
+
 class transform_jpeg2000rct_dpx_Raw_RGB_12_Packed_BE : public transform_dpx
 {
 public:
     transform_jpeg2000rct_dpx_Raw_RGB_12_Packed_BE(raw_frame* RawFrame, size_t x_offset, size_t y_offset, size_t w, size_t h) :
-        transform_dpx(RawFrame, x_offset, y_offset, w, h) {};
+        transform_dpx(RawFrame, x_offset, y_offset, w, h)
+    {
+        const auto& Plane = RawFrame->Plane(0);
+        auto Width = Plane->Width();
+        auto PixelsPerBlock = dpx::PixelsPerBlock((dpx::flavor)RawFrame->Flavor_Private);
+        auto HasBlockSpan = (x_offset % PixelsPerBlock) || ((x_offset + w) % PixelsPerBlock);
+
+        if (!HasBlockSpan)
+        {
+            FrameBufferBefore = nullptr;
+            Data_Temp_Pos_Begin = 0;
+            return;
+        }
+
+        if (!x_offset && !y_offset)
+            RawFrame->Finalize_Function = transform_jpeg2000rct_dpx_Raw_RGB_12_Packed_BE_Finalize;
+
+        auto FullLineBitCount = Width * 36;
+        auto FullLineBlockCount = FullLineBitCount / 32;
+        if (FullLineBitCount % 32)
+            FullLineBlockCount++;
+        auto SliceBeginBitCount = x_offset * 36;
+        auto SliceBeginBlockCount = SliceBeginBitCount / 32;
+        auto SliceEndBitCount = (x_offset + w) * 36;
+        auto SliceEndBlockCount = SliceEndBitCount / 32;
+
+        FrameBuffer = Plane->Buffer_Data() + (y_offset * FullLineBlockCount + SliceBeginBlockCount) * 4;
+        NextLine_Offset = SliceBeginBlockCount - SliceEndBlockCount; // -(SliceEndBlockCount - SliceBeginBlockCount)
+        NextLine_Offset += FullLineBlockCount;
+        NextLine_Offset *= 4;
+        Data_Temp_Pos_Begin = x_offset % 8;
+        
+        if (x_offset + w < Width)
+            FrameBufferBefore = Plane->Buffer_Extra().Data() + (MaxHorizontalSlicesCount * y_offset + (x_offset + w - 1) / w) * 4;
+        else
+            FrameBufferBefore = nullptr; // Last block in a line is padded so should be written immediately
+    }
 
     void From(pixel_t* y, pixel_t* u, pixel_t* v, pixel_t*)
     {
-        auto FrameBuffer_Temp_32 = (uint32_t*)FrameBuffer;
+        uint32_t Data_Temp = 0;
+        auto Data_Temp_Pos = Data_Temp_Pos_Begin;
+        uint32_t* FrameBuffer_Temp_32;
+        size_t x = 0;
 
-        for (size_t x = 0; x < w; x++)
+        FrameBuffer_Temp_32 = (uint32_t*)FrameBuffer;
+
+        for (; x < w; x++)
         {
-            uint32_t Data_Temp;
+            switch (Data_Temp_Pos)
+            {
+            case 0:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((b << 24) | (g << 12) | r));
                 Data_Temp = (b >> 8);
+                break;
             }
-            x++;
+            case 1:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((b << 28) | (g << 16) | (r << 4) | Data_Temp));
                 Data_Temp = (b >> 4);
+                break;
             }
-            x++;
+            case 2:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((g << 20) | (r << 8) | Data_Temp));
                 Data_Temp = b;
+                break;
             }
-            x++;
+            case 3:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((g << 24) | (r << 12) | Data_Temp));
                 Data_Temp = (b << 4) | (g >> 8);
+                break;
             }
-            x++;
+            case 4:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((g << 28) | (r << 16) | Data_Temp));
                 Data_Temp = (b << 8) | (g >> 4);
+                break;
             }
-            x++;
+            case 5:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((r << 20) | Data_Temp));
                 Data_Temp = (b << 12) | g;
+                break;
             }
-            x++;
+            case 6:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((r << 24) | Data_Temp));
                 Data_Temp = (b << 16) | (g << 4) | (r >> 8);
+                break;
             }
-            x++;
+            default:
             {
                 JPEG2000RCT(((pixel_t)1) << 12);
                 swap(b, g); // Exception indicated in specs, g and b are inverted
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((r << 28) | Data_Temp));
                 *(FrameBuffer_Temp_32++) = htob((uint32_t)((b << 20) | (g << 8) | (r >> 4)));
+                break;
+            }
+            }
+            Data_Temp_Pos = (Data_Temp_Pos + 1 ) % 8;
+        }
+        if (Data_Temp_Pos)
+        {
+            if (FrameBufferBefore)
+            {
+                auto FrameBufferBefore_Temp_32 = (uint32_t*)FrameBufferBefore;
+                *FrameBufferBefore_Temp_32 = htob(Data_Temp);
+                if ((intptr_t)NextLine_Offset < 0)
+                    FrameBufferBefore -= MaxHorizontalSlicesCount * 4;
+                else
+                    FrameBufferBefore += MaxHorizontalSlicesCount * 4;
+            }
+            else
+            {
+                *FrameBuffer_Temp_32 = htob(Data_Temp);
             }
         }
 
         FrameBuffer = (uint8_t*)FrameBuffer_Temp_32;
         Next();
     }
+
+protected:
+    uint8_t*    FrameBufferBefore;
+    uint32_t    Data_Temp_Pos_Begin;
 };
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Uncompressed/DPX/DPX.h
+++ b/Source/Lib/Uncompressed/DPX/DPX.h
@@ -59,6 +59,11 @@ public:
         Raw_Y_16_BE,
     ENUM_END(flavor)
 
+    enum class feature
+    {
+        BlockSpan = 8,
+    };
+
     // Info about flavors
     static size_t               BytesPerBlock(flavor Flavor);
     static size_t               PixelsPerBlock(flavor Flavor); // Need no overlap every x pixels

--- a/Source/Lib/Utils/RawFrame/RawFrame.cpp
+++ b/Source/Lib/Utils/RawFrame/RawFrame.cpp
@@ -67,8 +67,16 @@ void raw_frame::DPX_Create(size_t colorspace_type, size_t width, size_t height)
     {
         case 0: // YUV
         case 1: // JPEG2000-RCT --> RGB
-                Planes_.push_back(new plane(width, height, dpx::BytesPerBlock((dpx::flavor)Flavor_Private) * 8, dpx::PixelsPerBlock((dpx::flavor)Flavor_Private)));
-        default: ;
+        {
+            size_t ExtraBytes;
+            if (dpx::PixelsPerBlock((dpx::flavor)Flavor_Private) != 1)
+                ExtraBytes = height * MaxHorizontalSlicesCount * 4;
+            else
+                ExtraBytes = 0;
+
+            Planes_.push_back(new plane(width, height, dpx::BytesPerBlock((dpx::flavor)Flavor_Private) * 8, dpx::PixelsPerBlock((dpx::flavor)Flavor_Private), 0, 0, 32, ExtraBytes));
+        }
+        default:;
     }
 }
 


### PR DESCRIPTION
RGB 12-bit Packed BE has pixels crossing 32-bit block boundaries (8x3x12-bit in 9x32-bit) and the code for transforming from FFV1 decoder to DPX was not supporting if slices boundaries are not at DPX 32-block boundaries.
This PR removes this limitation.