### PR TITLE
Support of -i input_file options1 output_file1 options2 output_file2

### DIFF
--- a/Source/CLI/Global.h
+++ b/Source/CLI/Global.h
@@ -29,6 +29,7 @@ public:
     // Options
     map<string, string>         VideoInputOptions;
     map<string, string>         OutputOptions;
+    vector<string>              MoreOutputOptions;
     size_t                      AttachmentMaxSize;
     string                      rawcooked_reversibility_FileName;
     string                      OutputFileName;
@@ -107,6 +108,10 @@ private:
     thread*                     ProgressIndicator_Thread;
     size_t                      ProgressIndicator_Current;
     size_t                      ProgressIndicator_Total;
+
+    // Temp
+    bool                        NextFileNameIsOutput = false;
+    bool                        OptionsForOtherFiles = false;
 };
 
 #endif

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -313,6 +313,11 @@ int output::FFmpeg_Command(const char* FileName, global& Global, bool IgnoreReve
     Command += " -f matroska \"";
     Command += Global.OutputFileName;
     Command += '\"';
+    for (const auto& Option : Global.MoreOutputOptions)
+    {
+        Command += ' ';
+        Command += Option;
+    }
 
     if (Global.Actions[Action_FrameMd5])
     {


### PR DESCRIPTION
This permits to "copy/paste" a FFmpeg command to RAWcooked command, also for a 2nd output file e.g. framemd5 file.