### PR TITLE
AVI/v210: support of 00db frames

### DIFF
--- a/Source/Lib/Uncompressed/AVI/AVI.cpp
+++ b/Source/Lib/Uncompressed/AVI/AVI.cpp
@@ -139,6 +139,7 @@ ELEMENT_VOID(73747268, AVI__hdrl_strl_strh)
 ELEMENT_END()
 
 ELEMENT_BEGIN(AVI__movi)
+ELEMENT_VOID(30306462, AVI__movi_00db)
 ELEMENT_VOID(30306463, AVI__movi_00dc)
 ELEMENT_VOID(30317762, AVI__movi_01wb)
 ELEMENT_END()
@@ -148,6 +149,7 @@ ELEMENT_CASE(4C4953546D6F7669LL, AVI__movi)
 ELEMENT_END()
 
 ELEMENT_BEGIN(AVIX_movi)
+ELEMENT_VOID(30306462, AVI__movi_00db)
 ELEMENT_VOID(30306463, AVI__movi_00dc)
 ELEMENT_VOID(30317762, AVI__movi_01wb)
 ELEMENT_END()
@@ -516,6 +518,12 @@ void avi::AVI__movi()
 }
 
 //---------------------------------------------------------------------------
+void avi::AVI__movi_00db()
+{
+    AVI__movi_00dc();
+}
+
+//---------------------------------------------------------------------------
 void avi::AVI__movi_00dc()
 {
     if (Actions[Action_AcceptTruncated])
@@ -587,6 +595,12 @@ void avi::AVIX()
 void avi::AVIX_movi()
 {
     AVI__movi();
+}
+
+//---------------------------------------------------------------------------
+void avi::AVIX_movi_00db()
+{
+    AVI__movi_00dc();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Lib/Uncompressed/AVI/AVI.h
+++ b/Source/Lib/Uncompressed/AVI/AVI.h
@@ -89,10 +89,12 @@ private:
     AVI_ELEMENT(AVI__hdrl_strl_strf);
     AVI_ELEMENT(AVI__hdrl_strl_strh);
     AVI_ELEMENT(AVI__movi);
+    AVI_ELEMENT(AVI__movi_00db);
     AVI_ELEMENT(AVI__movi_00dc);
     AVI_ELEMENT(AVI__movi_01wb);
     AVI_ELEMENT(AVIX);
     AVI_ELEMENT(AVIX_movi);
+    AVI_ELEMENT(AVIX_movi_00db);
     AVI_ELEMENT(AVIX_movi_00dc);
     AVI_ELEMENT(AVIX_movi_01wb);
     AVI_ELEMENT(Void);


### PR DESCRIPTION
Some muxers use `00dc` ("Compressed video frame"), some other muxers use `00db` ("Uncompressed video frame"), [source](https://learn.microsoft.com/en-us/windows/win32/directshow/avi-riff-file-reference#stream-data-movi-list), and we forgot `00db` during the development of AVI/v210 support.

@lhibberdatnls 