### PR TITLE
Show a non misleading message if channel count is not supported

### DIFF
--- a/Source/Lib/Uncompressed/AVI/AVI.cpp
+++ b/Source/Lib/Uncompressed/AVI/AVI.cpp
@@ -407,7 +407,14 @@ void avi::AVI__hdrl_strl_strf_auds()
          && (Channels != 2 || (ChannelMask != 0x00000000 && ChannelMask != 0x00000003))
          && (Channels != 6 || (ChannelMask != 0x00000000 && ChannelMask != 0x0000003F && ChannelMask != 0x0000060F))
          && (Channels != 8 || (ChannelMask != 0x00000000 && ChannelMask != 0x0000063F)))
-            Unsupported(unsupported::fmt__ChannelMask);
+        {
+            bool ChannelCountSupported=false;
+            for (auto i=0; i<wav::flavor_Max; i++)
+                if (WAV_Channels((wav::flavor)i)==Channels)
+                    ChannelCountSupported=true;
+            if (ChannelCountSupported) //If no flavor has such channel count, error will be raised later about channel count, better error report than here
+                Unsupported(unsupported::fmt__ChannelMask);
+        }
         FormatTag = Get_L4();
         uint32_t SubFormat2 = Get_L4();
         uint32_t SubFormat3 = Get_B4();

--- a/Source/Lib/Uncompressed/WAV/WAV.cpp
+++ b/Source/Lib/Uncompressed/WAV/WAV.cpp
@@ -509,6 +509,16 @@ endianness WAV_Endianness(wav::flavor Flavor)
 }
 
 //---------------------------------------------------------------------------
+uint8_t wav::Channels()
+{
+    return WAV_Tested[Flavor].Channels;
+}
+uint8_t WAV_Channels(wav::flavor Flavor)
+{
+    return WAV_Tested[(uint8_t)Flavor].Channels;
+}
+
+//---------------------------------------------------------------------------
 string WAV_Flavor_String(uint8_t Flavor)
 {
     const auto& Info = WAV_Tested[(size_t)Flavor];

--- a/Source/Lib/Uncompressed/WAV/WAV.h
+++ b/Source/Lib/Uncompressed/WAV/WAV.h
@@ -32,6 +32,7 @@ public:
     uint8_t                     BitDepth();
     sign                        Sign();
     endianness                  Endianness();
+    uint8_t                     Channels();
 
     ENUM_BEGIN(flavor)
         PCM_44100_8_1_U,
@@ -132,6 +133,7 @@ string              WAV_Flavor_String(uint8_t Flavor);
 uint8_t             WAV_BitDepth(wav::flavor Flavor);
 sign                WAV_Sign(wav::flavor Flavor);
 endianness          WAV_Endianness(wav::flavor Flavor);
+uint8_t             WAV_Channels(wav::flavor Flavor);
 
 //---------------------------------------------------------------------------
 #endif


### PR DESCRIPTION
e.g. in case of 4-ch content in AVI, message about unsupported `ChannelMask` was displayed.