### PR TITLE
Fail if corrupted image header in the sequence

### DIFF
--- a/Project/GNU/CLI/test/test3.txt
+++ b/Project/GNU/CLI/test/test3.txt
@@ -5,3 +5,5 @@ BuggyPackages/IncompatibleVersion/RAWcooked_Alpha1/10bit.dpx.mkv fail
 BuggyPackages/CompatibleVersion/RAWcooked_Alpha2/10bit.dpx.mkv pass
 BuggyPackages/CompatibleVersion/RAWcooked_Alpha3/10bit.dpx.mkv pass
 BuggyPackages/SmallFile fail
+BuggyPackages/CorruptedFrame/SecondAndBody fail
+BuggyPackages/CorruptedFrame/SecondAndHeader fail

--- a/Source/Lib/Uncompressed/DPX/DPX.cpp
+++ b/Source/Lib/Uncompressed/DPX/DPX.cpp
@@ -24,6 +24,7 @@ namespace undecodable
 static const char* MessageText[] =
 {
     "file smaller than expected",
+    "file header",
     "version number of header format",
     "offset to data",
     "expected data size is bigger than real file size",
@@ -32,6 +33,7 @@ static const char* MessageText[] =
 enum code : uint8_t
 {
     BufferOverflow,
+    Header,
     VersionNumber,
     OffsetToData,
     DataSize,
@@ -266,7 +268,11 @@ void dpx::ParseBuffer()
 
     // Test that it is a DPX
     if (Buffer.Size() < 4)
+    {
+        if (IsDetected())
+            Undecodable(undecodable::Header);
         return;
+    }
 
     dpx_tested Info;
 
@@ -283,6 +289,8 @@ void dpx::ParseBuffer()
             IsBigEndian = true;
             break;
         default:
+            if (IsDetected())
+                Undecodable(undecodable::Header);
             return;
     }
     SetDetected();

--- a/Source/Lib/Uncompressed/EXR/EXR.cpp
+++ b/Source/Lib/Uncompressed/EXR/EXR.cpp
@@ -23,6 +23,7 @@ namespace undecodable
 static const char* MessageText[] =
 {
     "file smaller than expected",
+    "file header",
     "Version number",
     "Version flags",
     "Expected data size is bigger than real file size",
@@ -31,6 +32,7 @@ static const char* MessageText[] =
 enum code : uint8_t
 {
     BufferOverflow,
+    Header,
     VersionNumber,
     VersionFlags,
     DataSize,
@@ -198,12 +200,20 @@ void exr::ParseBuffer()
 {
     // Test that it is a EXR
     if (Buffer.Size() < 8)
+    {
+        if (IsDetected())
+            Undecodable(undecodable::Header);
         return;
+    }
 
     Buffer_Offset = 0;
     uint32_t MagicNumber = Get_B4();
     if (MagicNumber != 0x762F3101)
+    {
+        if (IsDetected())
+            Undecodable(undecodable::Header);
         return;
+    }
     SetDetected();
 
     uint32_t Version = Get_B4();

--- a/Source/Lib/Uncompressed/TIFF/TIFF.cpp
+++ b/Source/Lib/Uncompressed/TIFF/TIFF.cpp
@@ -25,6 +25,7 @@ namespace undecodable
 static const char* MessageText[] =
 {
     "file smaller than expected",
+    "file header",
     "IFD tag type",
     "IFD tag count",
     "FirstIFDOffset",
@@ -35,6 +36,7 @@ static const char* MessageText[] =
 enum code : uint8_t
 {
     BufferOverflow,
+    Header,
     IfdTagType,
     IfdTagCount,
     FirstIFDOffset,
@@ -384,7 +386,11 @@ void tiff::ParseBuffer()
             Info.Endianness = endianness::BE;
             break;
         default:
-            return;
+    {
+        if (IsDetected())
+            Undecodable(undecodable::Header);
+        return;
+    }
     }
     SetDetected();
     uint32_t FirstIFDOffset = Get_X4();

--- a/Source/Lib/Utils/FileIO/Input_Base.cpp
+++ b/Source/Lib/Utils/FileIO/Input_Base.cpp
@@ -37,7 +37,6 @@ input_base::~input_base()
 //---------------------------------------------------------------------------
 bool input_base::Parse(filemap* FileMap_Source, const buffer_view& Buffer_Source, size_t FileSize_Source)
 {
-    ClearInfo();
     FileMap = FileMap_Source;
     FileSize = FileSize_Source == (size_t)-1 ? Buffer_Source.Size() : FileSize_Source;
     Buffer = Buffer_Source;

--- a/Source/Lib/Utils/FileIO/Input_Base.h
+++ b/Source/Lib/Utils/FileIO/Input_Base.h
@@ -84,7 +84,7 @@ public:
 
     // Info
     bool                        IsDetected() { return Info[Info_IsDetected]; }
-    bool                        IsSupported() { return Info[Info_IsSupported]; }
+    bool                        IsSupported() { return Info[Info_IsSupported] && !HasErrors(); }
     bool                        HasErrors() { return Info[Info_HasErrors]; }
     input_info*                 InputInfo = nullptr;
 


### PR DESCRIPTION
There is a loss of content in an uncommon situation that applies only to DPX/TIFF/EXR sequences that contain a file where the first 4 bytes are not as expected (e.g. a DPX file where the first four bytes are not the “XPDS” magic value). Such a file is not decodable by any DPX/TIFF/EXR reader, but such invalid files could happen to be within such image sequences. For such a file, a RAWcooked encoding (for versions before 23.08) completely skips the invalid file so it is not represented in the resulting RAWcooked compressed file. For instance, with this sequence:
image_001.dpx (valid)
image_002.dpx (first four bytes are not 0x58504453, aka "XPDS" in ascii)
image_003.dpx (valid)
the resulting RAWcooked compressed file would only depict image_001.dpx and image_003.dpx, even though image_002.dpx may contain valid image data. Decoding that resulting RAWcooked compressed file would not recreate the original image_002.dpx file.
