### PR TITLE
Fail on any FFmpeg error

### DIFF
--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -83,6 +83,7 @@ int output::FFmpeg_Command(const char* FileName, global& Global, bool IgnoreReve
         Command += "ffmpeg";
     else
         Command += Global.BinName;
+    Command += " -xerror";
 
     // Disable stdin for ffmpeg
     if (Global.OutputOptions.find("n") != Global.OutputOptions.end() && Global.OutputOptions.find("y") != Global.OutputOptions.end())


### PR DESCRIPTION
Previously a tiny error in a stream was not making FFmpeg fails with a non zero exit code.
We now force a non zero exit code on any stream error.