### PR TITLE
Chocolatey: Do not rely on PackageVersion for URL

### DIFF
--- a/Project/Chocolatey/tools/chocolateyinstall.ps1
+++ b/Project/Chocolatey/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $packageArgs = @{
   PackageName    = "${env:ChocolateyPackageName}"
-  Url64bit       = "https://mediaarea.net/download/binary/rawcooked/${env:ChocolateyPackageVersion}/RAWcooked_CLI_${env:ChocolateyPackageVersion}_Windows_x64.zip"
+  Url64bit       = "https://mediaarea.net/download/binary/rawcooked/23.09/RAWcooked_CLI_23.09_Windows_x64.zip"
   Checksum64     = '0000000000000000000000000000000000000000000000000000000000000000'
   ChecksumType64 = 'sha256'
   UnzipLocation = "$(split-path -parent $MyInvocation.MyCommand.Definition)\rawcooked"


### PR DESCRIPTION
Chocolatey versioning rules has changed. Now leading zero are removed.