### PR TITLE
Add TIFF 8-bit LE

### DIFF
--- a/Project/GNU/CLI/test/test1.txt
+++ b/Project/GNU/CLI/test/test1.txt
@@ -251,6 +251,7 @@ Formats/TIFF/Flavors/Raw_Y_2_U/flower-minisblack-02.tif fail
 Formats/TIFF/Flavors/Raw_Y_4_U/flower-minisblack-04.tif fail
 Formats/TIFF/Flavors/Raw_Y_6_U/flower-minisblack-06.tif fail
 Formats/TIFF/Flavors/Raw_Y_8_U/flower-minisblack-08.tif pass
+Formats/TIFF/Flavors/Raw_Y_8_U/Raw_Y_8_U_LE.tif pass
 Formats/TIFF/Flavors/Raw_Y_10_U/flower-minisblack-10.tif fail
 Formats/TIFF/Flavors/Raw_Y_12_U/flower-minisblack-12.tif fail
 Formats/TIFF/Flavors/Raw_Y_14_U/flower-minisblack-14.tif fail

--- a/Source/Lib/Uncompressed/TIFF/TIFF.cpp
+++ b/Source/Lib/Uncompressed/TIFF/TIFF.cpp
@@ -147,6 +147,12 @@ struct tiff_tested
             ;
     }
 };
+struct dpx_also
+{
+    tiff_tested                 Test;
+    tiff::flavor                Flavor;
+};
+
 
 struct tiff_tested TIFF_Tested[] =
 {
@@ -155,11 +161,16 @@ struct tiff_tested TIFF_Tested[] =
     { colorspace::RGB     , 16, endianness::BE, 6 }, // 1x3x16-bit in 3x16-bit
     { colorspace::RGBA    ,  8, endianness::LE, 4 }, // 1x4x 8-bit in 4x 8-bit
     { colorspace::RGBA    , 16, endianness::LE, 8 }, // 1x4x16-bit in 4x16-bit
-    { colorspace::Y       ,  8, endianness::BE, 1 }, // 1x4x 8-bit in 1x 8-bit
+    { colorspace::Y       ,  8, endianness::LE, 1 }, // 1x4x 8-bit in 1x 8-bit
     { colorspace::Y       , 16, endianness::LE, 2 }, // 1x1x16-bit in 1x16-bit
     { colorspace::Y       , 16, endianness::BE, 2 }, // 1x1x16-bit in 1x16-bit
 };
 static_assert(tiff::flavor_Max == sizeof(TIFF_Tested) / sizeof(tiff_tested), IncoherencyMessage);
+
+struct dpx_also TIFF_Also[] =
+{
+    { { colorspace::Y        ,  8, endianness::BE }, tiff::flavor::Raw_Y_8_U                 },
+};
 
 //***************************************************************************
 // TIFF
@@ -605,6 +616,17 @@ void tiff::ParseBuffer()
         {
             Flavor = (decltype(Flavor))(&TIFF_Tested_Item - TIFF_Tested);
             break;
+        }
+    }
+    if (Flavor == (decltype(Flavor))-1)
+    {
+        for (const auto& TIFF_Also_Item : TIFF_Also)
+        {
+            if (TIFF_Also_Item.Test == Info)
+            {
+                Flavor = (decltype(Flavor))TIFF_Also_Item.Flavor;
+                break;
+            }
         }
     }
     if (Flavor == (decltype(Flavor))-1)


### PR DESCRIPTION
LE and BE have same content without byte endianness, so we just flag 8-bit LE as a duplicated of 8-bit BE