### PR TITLE
Support of DPX Y 10-bit from DIAMANT-Film

### DIFF
--- a/Source/Lib/Uncompressed/DPX/DPX.cpp
+++ b/Source/Lib/Uncompressed/DPX/DPX.cpp
@@ -358,6 +358,7 @@ void dpx::ParseBuffer()
     bool IsAltern = Info.BitDepth == 10
                  && Info.ColorSpace != colorspace::RGB
                  && (!memcmp(Buffer.Data() +  160, "Lasergraphics Inc.", 18) // Creator
+                  || !memcmp(Buffer.Data() +  160, "DIAMANT-Film", 12) // Creator
                   || !memcmp(Buffer.Data() + 1556, "Scanity", 7)); // Input device name
 
     if (IndustryHeaderSize && InputInfo)


### PR DESCRIPTION
It is not respecting DPX spec in the same manner as Lasergraphics & Scanity.

Need a FFmpeg build with a similar patch.