### PR TITLE
No license check if no encode

### DIFF
--- a/Source/CLI/Global.cpp
+++ b/Source/CLI/Global.cpp
@@ -914,18 +914,20 @@ int global::ManageCommandLine(const char* argv[], int argc)
         BinName = "ffmpeg";
 
     // License
-    if (License.LoadLicense(LicenseKey, StoreLicenseKey))
-        return true;
-    if (!License.IsSupported())
-    {
-        cerr << "\nOne or more requested features are not supported with the current license key.\n";
-        cerr << "****** Please contact info@mediaarea.net for a quote or a temporary key." << endl;
-        if (!IgnoreLicenseKey)
+    if (Actions[Action_Encode]) {
+        if (License.LoadLicense(LicenseKey, StoreLicenseKey))
+            return true;
+        if (!License.IsSupported())
+        {
+            cerr << "\nOne or more requested features are not supported with the current license key.\n";
+            cerr << "****** Please contact info@mediaarea.net for a quote or a temporary key." << endl;
+            if (!IgnoreLicenseKey)
+                return 1;
+            cerr << "       Ignoring the license for the moment.\n" << endl;
+        }
+        if (License.ShowLicense(ShowLicenseKey, SubLicenseId, SubLicenseDur))
             return 1;
-        cerr << "       Ignoring the license for the moment.\n" << endl;
     }
-    if (License.ShowLicense(ShowLicenseKey, SubLicenseId, SubLicenseDur))
-        return 1;
     if (Inputs.empty() && (ShowLicenseKey || SubLicenseId))
         return 0;
 

--- a/Source/CLI/Main.cpp
+++ b/Source/CLI/Main.cpp
@@ -292,7 +292,7 @@ bool parse_info::ParseFile_Input(input_base_uncompressed& SingleFile, input& Inp
     }
 
     // License
-    if (!Problem)
+    if (!Problem && Global.Actions[Action_Encode])
         Problem = !Global.License.IsSupported(SingleFile.ParserCode, (uint8_t)SingleFile.Flavor);
 
     // Technical limitations
@@ -688,7 +688,7 @@ int main(int argc, const char* argv[])
     RAWcooked.FileName = Global.rawcooked_reversibility_FileName;
     if (Global.Actions[Action_VersionValueIsAuto])
         RAWcooked.Version = rawcooked::version::mini;
-    else if (Global.Actions[Action_Version2])
+    else if (Global.Actions[Action_Version2]) 
         RAWcooked.Version = rawcooked::version::v2;
     int Value = 0;
     for (size_t i = 0; i < Input.Files.size(); i++)

--- a/Source/CLI/Output.cpp
+++ b/Source/CLI/Output.cpp
@@ -89,7 +89,7 @@ int output::FFmpeg_Command(const char* FileName, global& Global, bool IgnoreReve
     // Info
     bool Problem = false;
 
-    if (Streams.size() > 2 && !Global.License.IsSupported(feature::MultipleTracks))
+    if (Streams.size() > 2 && Global.Actions[Action_Encode] && !Global.License.IsSupported(feature::MultipleTracks))
     {
         if (!Global.Quiet)
             cerr << "*** More than 2 tracks is not supported by the current license key. ***" << endl;


### PR DESCRIPTION
No need to use the license for current conformance check and no need for future edition.